### PR TITLE
fix(evm): Correct context block height when trace transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Types of changes (Stanzas):
 Ref: https://keepachangelog.com/en/1.0.0/
 -->
 
+# Unreleased
+
+### Bug Fixes
+
+- (evm) [#3](https://github.com/EscanBE/evermint/pull/3) Correct context block height when trace transaction
+
 # Changelog
 
 ## [v12.1.6] - 2023-07-04

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -388,10 +388,10 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 		return nil, status.Errorf(codes.InvalidArgument, "output limit cannot be negative, got %d", req.TraceConfig.Limit)
 	}
 
-	// minus one to get the context of block beginning
-	contextHeight := req.BlockNumber - 1
+	// use the context of required context block beginning
+	contextHeight := req.BlockNumber
 	if contextHeight < 1 {
-		// 0 is a special value in `ContextWithHeight`
+		// 0 is a special value, means latest block
 		contextHeight = 1
 	}
 
@@ -465,10 +465,10 @@ func (k Keeper) TraceBlock(c context.Context, req *types.QueryTraceBlockRequest)
 		return nil, status.Errorf(codes.InvalidArgument, "output limit cannot be negative, got %d", req.TraceConfig.Limit)
 	}
 
-	// minus one to get the context of block beginning
-	contextHeight := req.BlockNumber - 1
+	// use the context of required context block beginning
+	contextHeight := req.BlockNumber
 	if contextHeight < 1 {
-		// 0 is a special value in `ContextWithHeight`
+		// 0 is a special value, means latest block
 		contextHeight = 1
 	}
 


### PR DESCRIPTION
Refer #2 

### Reference discussion 1
> > block height already minus by one in rpc
> >
> > https://github.com/evmos/ethermint/blob/57ed355c985d9f3116aba6aabfa2ee0f3f38e966/rpc/backend/tracing.go#L110-L114
> > 
> > Oh no, so currently it keep minus by one in grpc so actually minus by 2? If calling via API debug_traceTransaction?

> Fixing BlockNumber from [request](https://github.com/evmos/ethermint/blob/57ed355c985d9f3116aba6aabfa2ee0f3f38e966/rpc/backend/tracing.go#L98), no need minus 1

_Originally posted by `mmsqe` in https://github.com/evmos/ethermint/issues/1591#issuecomment-1373363076_

### Reference discussion 2
> The `contextHeight` is minus one to get to the state of block beginning, but the block number pass to evm context should not minus one.

_Originally posted by `yihuang` in https://github.com/evmos/ethermint/issues/1591#issuecomment-1375004878_
