### PR TITLE
fix(rename-chain): restore files should not be changed after rename chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Unreleased
 
+### Improvement
+
+- (rename-chain) [#4](https://github.com/EscanBE/evermint/pull/4) Restore files that should not be changed after rename chain
+
 ### Bug Fixes
 
 - (evm) [#3](https://github.com/EscanBE/evermint/pull/3) Correct context block height when trace transaction

--- a/rename-chain.sh
+++ b/rename-chain.sh
@@ -20,6 +20,10 @@ set -eu # Abort execution if any command fails
 # Run go tool to rename chain
 go run --tags renamechain rename_chain/main.go
 
+# Restore files that should not be changed
+git checkout -- CHANGELOG.md
+git checkout -- README.md
+
 # Update dependencies
 cd ./contracts
 npm i


### PR DESCRIPTION
Reason: [CHANGELOG.md](https://github.com/EscanBE/evermint/blob/main/CHANGELOG.md) keeps historical changes those patched in Evermint repo and repo URL should not be renamed to GitHub repo of new chain.