### PR TITLE
feat(store): add `inspect` command and sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 - (store) [#12](https://github.com/EscanBE/evermint/pull/12) Add local `snapshots` management commands
+- (store) [#14](https://github.com/EscanBE/evermint/pull/14) Add `inspect` command and sub-commands
 
 ### Improvement
 

--- a/cmd/evmd/inspect/block.go
+++ b/cmd/evmd/inspect/block.go
@@ -16,7 +16,7 @@ import (
 func BlockCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "block [latest | <height>]",
-		Short: "Inspect a specific block or latest block persisted in the db",
+		Short: "Get a specific block or latest block persisted in the db, marshal to JSON and print out",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var reqHeight int64
@@ -74,6 +74,16 @@ func BlockCmd() *cobra.Command {
 				panic(errors.Wrap(err, "failed to marshal block to JSON"))
 			}
 
+			fmt.Println("--- Block ---")
+			fmt.Println(string(bz))
+
+			meta := blockStore.LoadBaseMeta()
+			bz, err = json.Marshal(meta)
+			if err != nil {
+				panic(errors.Wrap(err, "failed to marshal block meta to JSON"))
+			}
+
+			fmt.Println("--- Meta ---")
 			fmt.Println(string(bz))
 		},
 	}

--- a/cmd/evmd/inspect/block.go
+++ b/cmd/evmd/inspect/block.go
@@ -1,0 +1,82 @@
+package inspect
+
+import (
+	"cosmossdk.io/errors"
+	"encoding/json"
+	"fmt"
+	dbm "github.com/cometbft/cometbft-db"
+	tmstore "github.com/cometbft/cometbft/store"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/spf13/cobra"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func BlockCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "block [latest | <height>]",
+		Short: "Inspect a specific block or latest block persisted in the db",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var reqHeight int64
+
+			reqHeightStr := strings.TrimSpace(strings.ToLower(args[0]))
+
+			switch strings.TrimSpace(strings.ToLower(args[0])) {
+			case "latest", "last", "0", "newest", "-1", "":
+				reqHeight = 0 // ya I know, but it's enhance the readability of the code
+				break
+			default:
+				var err error
+				reqHeight, err = strconv.ParseInt(reqHeightStr, 10, 64)
+				if err != nil {
+					panic(errors.Wrap(err, fmt.Sprintf("bad block height: %s", reqHeightStr)))
+				}
+				if reqHeight < 0 {
+					panic("invalid block height")
+				}
+				break
+			}
+
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			cfg := serverCtx.Config
+			home := cfg.RootDir
+
+			dataDir := filepath.Join(home, "data")
+			db, err := dbm.NewDB("blockstore", server.GetAppDBBackend(serverCtx.Viper), dataDir)
+			if err != nil {
+				panic(errors.Wrap(err, "error while opening db"))
+			}
+
+			blockStoreState := tmstore.LoadBlockStoreState(db)
+
+			if reqHeight == 0 {
+				reqHeight = blockStoreState.Height
+			} else {
+				if reqHeight > blockStoreState.Height {
+					panic(fmt.Sprintf("requested height %d is greater than latest height %d in db", reqHeight, blockStoreState.Height))
+				}
+			}
+
+			if reqHeight == blockStoreState.Height {
+				fmt.Println("Requested latest block height:", reqHeight)
+			} else {
+				fmt.Println("Latest block height:", blockStoreState.Height)
+				fmt.Println("Requested block height:", reqHeight)
+			}
+
+			blockStore := tmstore.NewBlockStore(db)
+			block := blockStore.LoadBlock(reqHeight)
+
+			bz, err := json.Marshal(block)
+			if err != nil {
+				panic(errors.Wrap(err, "failed to marshal block to JSON"))
+			}
+
+			fmt.Println(string(bz))
+		},
+	}
+
+	return cmd
+}

--- a/cmd/evmd/inspect/inspect.go
+++ b/cmd/evmd/inspect/inspect.go
@@ -1,0 +1,27 @@
+package inspect
+
+import (
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/spf13/cobra"
+)
+
+// Cmd creates a main CLI command
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect local database",
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			// Bind flags to the Context's Viper so the app construction can set
+			// options accordingly.
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			return serverCtx.Viper.BindPFlags(cmd.Flags())
+		},
+	}
+
+	cmd.AddCommand(
+		BlockCmd(),
+		LatestBlockNumberCmd(),
+	)
+
+	return cmd
+}

--- a/cmd/evmd/inspect/latest_block_number.go
+++ b/cmd/evmd/inspect/latest_block_number.go
@@ -1,0 +1,35 @@
+package inspect
+
+import (
+	"cosmossdk.io/errors"
+	"fmt"
+	dbm "github.com/cometbft/cometbft-db"
+	tmstore "github.com/cometbft/cometbft/store"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/spf13/cobra"
+	"path/filepath"
+)
+
+func LatestBlockNumberCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "latest-block-number",
+		Short: "Get the latest block number persisted in the db",
+		Run: func(cmd *cobra.Command, args []string) {
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			cfg := serverCtx.Config
+			home := cfg.RootDir
+
+			dataDir := filepath.Join(home, "data")
+			db, err := dbm.NewDB("blockstore", server.GetAppDBBackend(serverCtx.Viper), dataDir)
+			if err != nil {
+				panic(errors.Wrap(err, "error while opening db"))
+			}
+
+			blockStoreState := tmstore.LoadBlockStoreState(db)
+
+			fmt.Println("Latest block height available in database:", blockStoreState.Height)
+		},
+	}
+
+	return cmd
+}

--- a/cmd/evmd/root.go
+++ b/cmd/evmd/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/EscanBE/evermint/v12/cmd/evmd/inspect"
 	"github.com/EscanBE/evermint/v12/constants"
 	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
@@ -160,6 +161,7 @@ You gonna get "data/application.db" unpacked
 			)
 			return snapshotCmd
 		}(),
+		inspect.Cmd(),
 	}
 
 	// End of command rename chain


### PR DESCRIPTION
Closes #9 

New commands:
- `inspect latest-block-number`: Get the latest block number persisted in the db
- `inspect block`: Get a specific block or latest block persisted in the db, marshal to JSON and print out