### PR TITLE
fix(gov): setting max metadata length for gov proposals submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 - (rename-chain) [#18](https://github.com/EscanBE/evermint/pull/18) Check network chain-id string must contain EVM chain-id
+- (gov) [#21](https://github.com/EscanBE/evermint/pull/21) Setting max metadata length for gov proposals submission
 
 ### State Machine Breaking
 

--- a/app/app.go
+++ b/app/app.go
@@ -466,10 +466,8 @@ func NewEvermint(
 		AddRoute(incentivestypes.RouterKey, incentives.NewIncentivesProposalHandler(&chainApp.IncentivesKeeper))
 
 	govConfig := govtypes.DefaultConfig()
-	/*
-		Example of setting gov params:
-		govConfig.MaxMetadataLen = 10000
-	*/
+	govConfig.MaxMetadataLen = 10000
+
 	govKeeper := govkeeper.NewKeeper(
 		appCodec, keys[govtypes.StoreKey], chainApp.AccountKeeper, chainApp.BankKeeper,
 		stakingKeeper, chainApp.MsgServiceRouter(), govConfig, authAddr,


### PR DESCRIPTION
Describe: GOV from v0.47 needs this