### PR TITLE
chores(flags): change default gas adjustment to 1.2 and update default value of some flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvement
 
 - (test) [#10](https://github.com/EscanBE/evermint/pull/10) Use Testnet chain-id instead of Mainnet chain-id for tests
+- (flags) [#22](https://github.com/EscanBE/evermint/pull/22) Change default gas adjustment to 1.2 and update default value of some flags
 
 ### Bug Fixes
 

--- a/cmd/evmd/root.go
+++ b/cmd/evmd/root.go
@@ -389,3 +389,7 @@ func initTendermintConfig() *tmcfg.Config {
 
 	return cfg
 }
+
+func init() {
+	flags.DefaultGasAdjustment = 1.2
+}

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -73,7 +73,7 @@ const (
 
 // AddTxFlags adds common flags for commands to post tx
 func AddTxFlags(cmd *cobra.Command) (*cobra.Command, error) {
-	cmd.PersistentFlags().String(flags.FlagChainID, "testnet", "Specify Chain ID for sending Tx")
+	cmd.PersistentFlags().String(flags.FlagChainID, "", "Specify Chain ID for sending Tx")
 	cmd.PersistentFlags().String(flags.FlagFrom, "", "Name or address of private key with which to sign")
 	cmd.PersistentFlags().String(flags.FlagFees, "", fmt.Sprintf("Fees to pay along with transaction; eg: 10%s", constants.BaseDenom))
 	cmd.PersistentFlags().String(flags.FlagGasPrices, "", fmt.Sprintf("Gas prices to determine the transaction fee (e.g. 10%s)", constants.BaseDenom))


### PR DESCRIPTION
Main purpose of this PR is about to change default gas adjustment (cli) to 1.2 to reduce out of gas error during consensus, due to different of context between simulation and actual execution.