### PR TITLE
chores(flags): revert set gas adjustment 1.2 made in #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-- (flags) [#23](https://github.com/EscanBE/evermint/pull/23) Change default gas adjustment to 1.2 and update default value of some flags (backport #22)
+- (flags) [#23](https://github.com/EscanBE/evermint/pull/23) ~~Change default gas adjustment to 1.2 and~~ update default value of some flags (backport #22), partially reverted by [#27](https://github.com/EscanBE/evermint/pull/27)
 
 ### State Machine Breaking
 

--- a/cmd/evmd/root.go
+++ b/cmd/evmd/root.go
@@ -354,7 +354,3 @@ func initTendermintConfig() *tmcfg.Config {
 
 	return cfg
 }
-
-func init() {
-	flags.DefaultGasAdjustment = 1.2
-}


### PR DESCRIPTION
This revert a mistake that `DefaultGasAdjustment` is a constants and can not be modified in cosmos-sdk v0.46