### PR TITLE
imp(fee): reject cosmos txs that fee denom is not evm denom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (test) [#10](https://github.com/EscanBE/evermint/pull/10) Use Testnet chain-id instead of Mainnet chain-id for tests
 - (flags) [#22](https://github.com/EscanBE/evermint/pull/22) Change default gas adjustment to 1.2 and update default value of some flags
+- (fee) [#37](https://github.com/EscanBE/evermint/pull/37) Reject cosmos txs that fee denom is not evm denom
 
 ### Bug Fixes
 

--- a/app/ante/cosmos/min_price_test.go
+++ b/app/ante/cosmos/min_price_test.go
@@ -2,6 +2,7 @@ package cosmos_test
 
 import (
 	sdkmath "cosmossdk.io/math"
+	"fmt"
 	cosmosante "github.com/EscanBE/evermint/v12/app/ante/cosmos"
 	"github.com/EscanBE/evermint/v12/constants"
 	"github.com/EscanBE/evermint/v12/rename_chain/marker"
@@ -105,8 +106,8 @@ func (suite *AnteTestSuite) TestMinGasPriceDecorator() {
 			true,
 		},
 		{
-			"invalid cosmos tx with wrong denom",
-			func() sdk.Tx {
+			name: "invalid cosmos tx with wrong denom",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(10)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -115,9 +116,25 @@ func (suite *AnteTestSuite) TestMinGasPriceDecorator() {
 				txBuilder := suite.CreateTestCosmosTxBuilder(sdkmath.NewInt(10), "stake", &testMsg)
 				return txBuilder.GetTx()
 			},
-			false,
-			"provided fee < minimum global fee",
-			true,
+			expPass:             false,
+			errMsg:              fmt.Sprintf("fee can only be %s", constants.BaseDenom),
+			allowPassOnSimulate: false,
+		},
+		{
+			name: "valid cosmos tx but wrong fee denom",
+			malleate: func() sdk.Tx {
+				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
+				params.MinGasPrice = sdk.NewDec(10)
+				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
+				suite.Require().NoError(err)
+
+				txBuilder := suite.CreateTestCosmosTxBuilder(sdkmath.NewInt(10), "stake", &testMsg)
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("stake", sdkmath.NewInt(20))))
+				return txBuilder.GetTx()
+			},
+			expPass:             false,
+			errMsg:              fmt.Sprintf("fee can only be %s", constants.BaseDenom),
+			allowPassOnSimulate: false,
 		},
 	}
 

--- a/app/ante/cosmos/min_price_test.go
+++ b/app/ante/cosmos/min_price_test.go
@@ -136,6 +136,37 @@ func (suite *AnteTestSuite) TestMinGasPriceDecorator() {
 			errMsg:              fmt.Sprintf("fee can only be %s", constants.BaseDenom),
 			allowPassOnSimulate: false,
 		},
+		{
+			name: "valid cosmos tx, multiple fee and contains at least one is wrong fee denom",
+			malleate: func() sdk.Tx {
+				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
+				params.MinGasPrice = sdk.NewDec(10)
+				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
+				suite.Require().NoError(err)
+
+				txBuilder := suite.CreateTestCosmosTxBuilder(sdkmath.NewInt(10), "stake", &testMsg)
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("stake", sdkmath.NewInt(20)), sdk.NewCoin(constants.BaseDenom, sdkmath.NewInt(20))))
+				return txBuilder.GetTx()
+			},
+			expPass:             false,
+			errMsg:              fmt.Sprintf("fee can only be %s", constants.BaseDenom),
+			allowPassOnSimulate: false,
+		},
+		{
+			name: "valid cosmos tx, insufficient fee",
+			malleate: func() sdk.Tx {
+				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
+				params.MinGasPrice = sdk.NewDec(10)
+				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
+				suite.Require().NoError(err)
+
+				txBuilder := suite.CreateTestCosmosTxBuilder(sdkmath.NewInt(1), constants.BaseDenom, &testMsg)
+				return txBuilder.GetTx()
+			},
+			expPass:             false,
+			errMsg:              "provided fee < minimum global fee",
+			allowPassOnSimulate: true,
+		},
 	}
 
 	for _, et := range execTypes {


### PR DESCRIPTION
New rules:
- Fee must be empty (compatible with MinGasPrice is zero)
- Or fee must be single element array of EVM-denom
- Otherwise reject