### PR TITLE
fix(test): set chain-id into client.toml during init testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (gas) [#28](https://github.com/EscanBE/evermint/pull/28) Adjust max-gas computation logic to prevent potential out of gas issue
 - (fee) [#30](https://github.com/EscanBE/evermint/pull/30) Handle deduct zero fee of zero fee tx when x/feemarket disabled and min gas price is zero
 - (rpc+store) [#32](https://github.com/EscanBE/evermint/pull/32) Fix some concurrency issue in rpc and correct iavl tag
+- (test) [#50](https://github.com/EscanBE/evermint/pull/50) Set chain-id into client.toml during init testnet
 
 ### Client Breaking
 

--- a/client/testnet.go
+++ b/client/testnet.go
@@ -8,9 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/EscanBE/evermint/v12/constants"
+	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
+	"github.com/spf13/viper"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -390,6 +393,23 @@ func initTestnetFiles(
 		}
 
 		srvconfig.WriteConfigFile(filepath.Join(nodeDir, "config/app.toml"), appConfig)
+
+		// set chain-id into client.toml
+		tmpClientCtx := client.Context{
+			HomeDir: nodeDir,
+			Viper:   viper.New(),
+		}
+		_, _ = clientconfig.ReadFromClientConfig(tmpClientCtx) // this action will create the client.toml file if not exists
+		clientConfigFilePath := filepath.Join(nodeDir, "config", "client.toml")
+		bzClientToml, err := os.ReadFile(clientConfigFilePath)
+		if err != nil {
+			return errors.Wrap(err, "failed to read client.toml")
+		}
+		bzClientToml = []byte(strings.Replace(string(bzClientToml), "chain-id", fmt.Sprintf("chain-id = \"%s\" # ", args.chainID), 1))
+		err = os.WriteFile(clientConfigFilePath, bzClientToml, 0o644)
+		if err != nil {
+			return errors.Wrap(err, "failed to write client.toml")
+		}
 	}
 
 	for _, normalAccountAddr := range normalAccountAddresses {

--- a/cmd/evmd/testnet.go
+++ b/cmd/evmd/testnet.go
@@ -8,17 +8,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/EscanBE/evermint/v12/constants"
-	"net"
-	"os"
-	"path/filepath"
-
-	"github.com/ethereum/go-ethereum/common"
-
 	tmconfig "github.com/cometbft/cometbft/config"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 	"github.com/cometbft/cometbft/types"
 	tmtime "github.com/cometbft/cometbft/types/time"
+	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -387,6 +388,23 @@ func initTestnetFiles(
 		}
 
 		srvconfig.WriteConfigFile(filepath.Join(nodeDir, "config/app.toml"), appConfig)
+
+		// set chain-id into client.toml
+		tmpClientCtx := client.Context{
+			HomeDir: nodeDir,
+			Viper:   viper.New(),
+		}
+		_, _ = clientconfig.ReadFromClientConfig(tmpClientCtx) // this action will create the client.toml file if not exists
+		clientConfigFilePath := filepath.Join(nodeDir, "config", "client.toml")
+		bzClientToml, err := os.ReadFile(clientConfigFilePath)
+		if err != nil {
+			return errors.Wrap(err, "failed to read client.toml")
+		}
+		bzClientToml = []byte(strings.Replace(string(bzClientToml), "chain-id", fmt.Sprintf("chain-id = \"%s\" # ", args.chainID), 1))
+		err = os.WriteFile(clientConfigFilePath, bzClientToml, 0o644)
+		if err != nil {
+			return errors.Wrap(err, "failed to write client.toml")
+		}
 	}
 
 	for _, normalAccountAddr := range normalAccountAddresses {


### PR DESCRIPTION
Problem: when running `make localnet-remake` (previously: `localnet-start`), the testnet network can not be started due to problem with `--chain-id` flag from sdk v0.47

Context: Evermint already implemented to read chain-id from `client.toml` but cmd `evmd testnet init-files` does not invoke setting `chain-id` into `client.toml` file of nodes

Solution: `evmd testnet init-files` will set chain-id into `client.toml`