### PR TITLE
imp(test): set chain id into client toml during init testnet v12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Types of changes (Stanzas):
 Ref: https://keepachangelog.com/en/1.0.0/
 -->
 
+# Unreleased
+
+### Improvements
+
+- (test) [#51](https://github.com/EscanBE/evermint/pull/51) Set chain-id into client.toml during init testnet
+
 # Evermint changelog
 
 ## [v12.2.2] - 2024-01-03

--- a/client/testnet.go
+++ b/client/testnet.go
@@ -8,9 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/EscanBE/evermint/v12/constants"
+	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
+	"github.com/spf13/viper"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -390,6 +393,23 @@ func initTestnetFiles(
 		}
 
 		srvconfig.WriteConfigFile(filepath.Join(nodeDir, "config/app.toml"), appConfig)
+
+		// set chain-id into client.toml
+		tmpClientCtx := client.Context{
+			HomeDir: nodeDir,
+			Viper:   viper.New(),
+		}
+		_, _ = clientconfig.ReadFromClientConfig(tmpClientCtx) // this action will create the client.toml file if not exists
+		clientConfigFilePath := filepath.Join(nodeDir, "config", "client.toml")
+		bzClientToml, err := os.ReadFile(clientConfigFilePath)
+		if err != nil {
+			return errors.Wrap(err, "failed to read client.toml")
+		}
+		bzClientToml = []byte(strings.Replace(string(bzClientToml), "chain-id", fmt.Sprintf("chain-id = \"%s\" # ", args.chainID), 1))
+		err = os.WriteFile(clientConfigFilePath, bzClientToml, 0o644)
+		if err != nil {
+			return errors.Wrap(err, "failed to write client.toml")
+		}
 	}
 
 	for _, normalAccountAddr := range normalAccountAddresses {


### PR DESCRIPTION
This PR is kinda a sync code changes in #50 for a bug that does not occurs in the v12.2 release branch