### PR TITLE
refactor(deps): use vanilla cosmos-sdk v0.47.5

### DIFF
--- a/cmd/evmd/root.go
+++ b/cmd/evmd/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/EscanBE/evermint/v12/cmd/evmd/inspect"
+	cmdutils "github.com/EscanBE/evermint/v12/cmd/evmd/utils"
 	"github.com/EscanBE/evermint/v12/constants"
 	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
@@ -175,7 +176,7 @@ You gonna get "data/application.db" unpacked
 		addModuleInitFlags,
 	)
 
-	// add keybase, auxiliary RPC, query, and tx child commands
+	// add basic commands: auxiliary RPC, query, and tx child commands
 	rootCmd.AddCommand(
 		rpc.StatusCommand(),
 		queryCommand(),
@@ -189,6 +190,13 @@ You gonna get "data/application.db" unpacked
 
 	// add rosetta
 	rootCmd.AddCommand(rosettaCmd.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Codec))
+
+	const minimumDefaultGasAdjustment = 1.2
+	if //goland:noinspection GoBoolExpressions
+	flags.DefaultGasAdjustment < minimumDefaultGasAdjustment {
+		// visit all flags to change the default gas adjustment
+		cmdutils.UpdateRegisteredGasAdjustmentFlags(rootCmd, minimumDefaultGasAdjustment)
+	}
 
 	return rootCmd, encodingConfig
 }
@@ -388,8 +396,4 @@ func initTendermintConfig() *tmcfg.Config {
 	// cfg.P2P.MaxNumOutboundPeers = 40
 
 	return cfg
-}
-
-func init() {
-	flags.DefaultGasAdjustment = 1.2
 }

--- a/cmd/evmd/utils/flag_util.go
+++ b/cmd/evmd/utils/flag_util.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"strconv"
+)
+
+// UpdateRegisteredGasAdjustmentFlags takes input is command, walking recursive sub-commands
+// and try to update all gas adjustment flags with minimumValue if it is less than minimumValue.
+func UpdateRegisteredGasAdjustmentFlags(cmd *cobra.Command, minimumValue float64) {
+	flagModifier := func(flag *pflag.Flag) {
+		if flag == nil {
+			return
+		}
+
+		if flag.Name == flags.FlagGasAdjustment {
+			tryUpdateGasAdjustmentFlag(flag, minimumValue)
+		}
+	}
+
+	cmd.PersistentFlags().VisitAll(flagModifier)
+
+	cmd.Flags().VisitAll(flagModifier)
+
+	subCommands := cmd.Commands()
+	if len(subCommands) > 0 {
+		for _, subCommand := range subCommands {
+			UpdateRegisteredGasAdjustmentFlags(subCommand, minimumValue)
+		}
+	}
+}
+
+// tryUpdateGasAdjustmentFlag will update the flag value if it is less than minimumValue.
+func tryUpdateGasAdjustmentFlag(flag *pflag.Flag, minimumValue float64) {
+	if flag.Name != flags.FlagGasAdjustment {
+		panic(fmt.Sprintf("not --%s flag", flags.FlagGasAdjustment))
+	}
+
+	value := flag.Value
+	if value == nil {
+		return // un-expected, ignore
+	}
+
+	currentGasAdjustment, err := strconv.ParseFloat(value.String(), 64)
+	if err != nil {
+		return // ignore
+	}
+
+	if currentGasAdjustment >= minimumValue {
+		return
+	}
+
+	minimumStrValue := strconv.FormatFloat(minimumValue, 'g', -1, 64) // use the same conversion as lib
+	err = value.Set(minimumStrValue)
+	if err != nil {
+		// ignore error
+		return
+	}
+
+	// updated
+	flag.DefValue = minimumStrValue
+}

--- a/go.mod
+++ b/go.mod
@@ -237,8 +237,6 @@ require (
 replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
-	// use Cosmos-SDK fork to enable Ledger functionality
-	github.com/cosmos/cosmos-sdk => github.com/evmos/cosmos-sdk v0.47.5-evmos.2
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 	// replace broken goleveldb

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ github.com/cosmos/btcutil v1.0.5 h1:t+ZFcX77LpKtDBhjucvnOH8C2l2ioGsBNEQ3jef8xFk=
 github.com/cosmos/btcutil v1.0.5/go.mod h1:IyB7iuqZMJlthe2tkIFL33xPyzbFYP0XVdS8P5lUPis=
 github.com/cosmos/cosmos-proto v1.0.0-beta.3 h1:VitvZ1lPORTVxkmF2fAp3IiA61xVwArQYKXTdEcpW6o=
 github.com/cosmos/cosmos-proto v1.0.0-beta.3/go.mod h1:t8IASdLaAq+bbHbjq4p960BvcTqtwuAxid3b/2rOD6I=
+github.com/cosmos/cosmos-sdk v0.47.5 h1:n1+WjP/VM/gAEOx3TqU2/Ny734rj/MX1kpUnn7zVJP8=
+github.com/cosmos/cosmos-sdk v0.47.5/go.mod h1:EHwCeN9IXonsjKcjpS12MqeStdZvIdxt3VYXhus3G3c=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
@@ -463,8 +465,6 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.10.26 h1:i/7d9RBBwiXCEuyduBQzJw/mKmnvzsN14jqBmytw72s=
 github.com/ethereum/go-ethereum v1.10.26/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
-github.com/evmos/cosmos-sdk v0.47.5-evmos.2 h1:fyhM0NYw/FnP4ZBXzQ7k+G4fXhfdU07MONoYrGlOCpc=
-github.com/evmos/cosmos-sdk v0.47.5-evmos.2/go.mod h1:EHwCeN9IXonsjKcjpS12MqeStdZvIdxt3VYXhus3G3c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=


### PR DESCRIPTION
Compare:
| Feature | Vanilla Cosmos-SDK | Custom Cosmos-SDK | Solve |
| --- | --- | --- | --- |
| Set default value for `--gas-adjustment` from 1.0 to 1.2 | ❌ | ✅ | ✅ Re-implemented successfully without dependency to custom SDK ([1](https://github.com/EscanBE/evermint/commit/399db0a5e035b44221eacbfd65919de86a52ea20) & [2](https://github.com/EscanBE/evermint/commit/cadc16de03225f3bdd315a9c80886cc68338643a)) |
| Allow `MsgCancelUnbondingDelegation` in `authz` | ❌ | ✅ | ❌ Since Evermint is for R&D so this Custom behavior is not really important => Drop |

Summary:
- Dependency changes: use vanilla Cosmos-SDK v0.47.5 instead of custom one
- Drop custom feature that allow `MsgCancelUnbondingDelegation` in `authz`