### PR TITLE
fix: prevent panic when building error message of fee which overflow int64

### DIFF
--- a/app/ante/evm/fees.go
+++ b/app/ante/evm/fees.go
@@ -98,8 +98,8 @@ func (empd EthMinGasPriceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 		if fee.LT(requiredFee) {
 			return ctx, errorsmod.Wrapf(
 				errortypes.ErrInsufficientFee,
-				"provided fee < minimum global fee (%d < %d). Please increase the priority tip (for EIP-1559 txs) or the gas prices (for access list or legacy txs)", //nolint:lll
-				fee.TruncateInt().Int64(), requiredFee.TruncateInt().Int64(),
+				"provided fee < minimum global fee (%s < %s). Please increase the priority tip (for EIP-1559 txs) or the gas prices (for access list or legacy txs)", //nolint:lll
+				fee.TruncateInt().String(), requiredFee.TruncateInt().String(),
 			)
 		}
 	}


### PR DESCRIPTION
This PR aims to patch a potential panic where error message constructs using two variables that possible larger than `math.MaxInt64` thus causing panic.

2 testcases was added to make sure neither of them, when overflow of int64, would causes panic