### PR TITLE
fix(evm): general use zero gas config for EVM exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (cleanup) [#92](https://github.com/EscanBE/evermint/pull/92) Cleanup un-used `x/evm` and `x/erc20` types
 - (indexer) [#96](https://github.com/EscanBE/evermint/pull/96) Make EVMTxIndexer mandatory service, starts before Json-RPC
 - (test) [#100](https://github.com/EscanBE/evermint/pull/100) Add some edge test cases + benchmark tests
+- (evm) [#103](https://github.com/EscanBE/evermint/pull/103) General use zero gas config for EVM exec
 
 ### Bug Fixes
 

--- a/app/ante/evm/setup_ctx.go
+++ b/app/ante/evm/setup_ctx.go
@@ -2,12 +2,12 @@ package evm
 
 import (
 	"errors"
+	"github.com/EscanBE/evermint/v12/utils"
 	"strconv"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 	evmtypes "github.com/EscanBE/evermint/v12/x/evm/types"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -34,9 +34,8 @@ func (esc EthSetupContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 	}
 
 	// We need to setup an empty gas config so that the gas is consistent with Ethereum.
-	newCtx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter()).
-		WithKVGasConfig(storetypes.GasConfig{}).
-		WithTransientKVGasConfig(storetypes.GasConfig{})
+	newCtx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+	newCtx = utils.UseZeroGasConfig(newCtx)
 
 	// Reset transient gas used to prepare the execution of current cosmos tx.
 	// Transient gas-used is necessary to sum the gas-used of cosmos tx, when it contains multiple eth msgs.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/EscanBE/evermint/v12/constants"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"strings"
 
 	"github.com/EscanBE/evermint/v12/crypto/ethsecp256k1"
@@ -78,4 +79,8 @@ func GetEvermintAddressFromBech32(address string) (sdk.AccAddress, error) {
 	}
 
 	return sdk.AccAddress(addressBz), nil
+}
+
+func UseZeroGasConfig(ctx sdk.Context) sdk.Context {
+	return ctx.WithKVGasConfig(storetypes.GasConfig{}).WithTransientKVGasConfig(storetypes.GasConfig{})
 }

--- a/x/erc20/keeper/ibc_callbacks.go
+++ b/x/erc20/keeper/ibc_callbacks.go
@@ -2,8 +2,8 @@ package keeper
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"github.com/EscanBE/evermint/v12/utils"
 	"github.com/armon/go-metrics"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
@@ -43,9 +43,7 @@ func (k Keeper) OnRecvPacket(
 	}
 
 	// use a zero gas config to avoid extra costs for the relayers
-	ctx = ctx.
-		WithKVGasConfig(storetypes.GasConfig{}).
-		WithTransientKVGasConfig(storetypes.GasConfig{})
+	ctx = utils.UseZeroGasConfig(ctx)
 
 	if !k.IsERC20Enabled(ctx) {
 		return ack
@@ -166,9 +164,7 @@ func (k Keeper) ConvertCoinToERC20FromPacket(ctx sdk.Context, data transfertypes
 	}
 
 	// use a zero gas config to avoid extra costs for the relayers
-	ctx = ctx.
-		WithKVGasConfig(storetypes.GasConfig{}).
-		WithTransientKVGasConfig(storetypes.GasConfig{})
+	ctx = utils.UseZeroGasConfig(ctx)
 
 	// assume that all module accounts on this chain need to have their tokens in the
 	// IBC representation as opposed to ERC20

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -24,12 +24,6 @@ import (
 // Not valid Ethereum address
 const invalidAddress = "0x0000"
 
-// expGasConsumed is the gas consumed in traceTx setup
-const expGasConsumed = 0x18f5
-
-// expGasConsumedWithFeeMkt is the gas consumed in traceTx setup with enabled x/feemarket
-const expGasConsumedWithFeeMkt = 0x18ef
-
 func (suite *KeeperTestSuite) TestQueryAccount() {
 	var (
 		req        *types.QueryAccountRequest
@@ -777,7 +771,6 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 		expPass         bool
 		traceResponse   string
 		enableFeemarket bool
-		expGasConsumed  uint64
 	}{
 		{
 			msg: "default trace",
@@ -785,9 +778,8 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 				traceConfig = nil
 				predecessors = []*types.MsgEthereumTx{}
 			},
-			expPass:        true,
-			traceResponse:  "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
-			expGasConsumed: expGasConsumed,
+			expPass:       true,
+			traceResponse: "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
 		},
 		{
 			msg: "default trace with filtered response",
@@ -802,7 +794,6 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			expPass:         true,
 			traceResponse:   "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
 			enableFeemarket: false,
-			expGasConsumed:  expGasConsumed,
 		},
 		{
 			msg: "javascript tracer",
@@ -812,9 +803,8 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 				}
 				predecessors = []*types.MsgEthereumTx{}
 			},
-			expPass:        true,
-			traceResponse:  "[]",
-			expGasConsumed: expGasConsumed,
+			expPass:       true,
+			traceResponse: "[]",
 		},
 		{
 			msg: "default trace with enableFeemarket",
@@ -829,7 +819,6 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			expPass:         true,
 			traceResponse:   "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
 			enableFeemarket: true,
-			expGasConsumed:  expGasConsumedWithFeeMkt,
 		},
 		{
 			msg: "javascript tracer with enableFeemarket",
@@ -842,7 +831,6 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			expPass:         true,
 			traceResponse:   "[]",
 			enableFeemarket: true,
-			expGasConsumed:  expGasConsumedWithFeeMkt,
 		},
 		{
 			msg: "default tracer with predecessors",
@@ -866,7 +854,6 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			expPass:         true,
 			traceResponse:   "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
 			enableFeemarket: false,
-			expGasConsumed:  expGasConsumed,
 		},
 		{
 			msg: "invalid trace config - Negative Limit",
@@ -878,8 +865,7 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 					Limit:          -1,
 				}
 			},
-			expPass:        false,
-			expGasConsumed: 0,
+			expPass: false,
 		},
 		{
 			msg: "invalid trace config - Invalid Tracer",
@@ -891,8 +877,7 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 					Tracer:         "invalid_tracer",
 				}
 			},
-			expPass:        false,
-			expGasConsumed: expGasConsumed,
+			expPass: false,
 		},
 		{
 			msg: "invalid trace config - Invalid Timeout",
@@ -904,8 +889,7 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 					Timeout:        "wrong_time",
 				}
 			},
-			expPass:        false,
-			expGasConsumed: expGasConsumed,
+			expPass: false,
 		},
 		{
 			msg: "default tracer with contract creation tx as predecessor but 'create' param disabled",
@@ -936,9 +920,8 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 				err := suite.app.EvmKeeper.SetParams(suite.ctx, params)
 				suite.Require().NoError(err)
 			},
-			expPass:        true,
-			traceResponse:  "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
-			expGasConsumed: 0x36da, // gas consumed in traceTx setup + gas consumed in malleate func
+			expPass:       true,
+			traceResponse: "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
 		},
 		{
 			msg: "invalid chain id",
@@ -948,8 +931,7 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 				tmp := sdkmath.NewInt(1)
 				chainID = &tmp
 			},
-			expPass:        false,
-			expGasConsumed: expGasConsumed,
+			expPass: false,
 		},
 	}
 
@@ -992,7 +974,6 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			} else {
 				suite.Require().Error(err)
 			}
-			suite.Require().Equal(tc.expGasConsumed, suite.ctx.GasMeter().GasConsumed())
 			// Reset for next test case
 			chainID = nil
 		})
@@ -1014,16 +995,14 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 		expPass         bool
 		traceResponse   string
 		enableFeemarket bool
-		expGasConsumed  uint64
 	}{
 		{
 			msg: "default trace",
 			malleate: func() {
 				traceConfig = nil
 			},
-			expPass:        true,
-			traceResponse:  "[{\"result\":{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PU",
-			expGasConsumed: expGasConsumed,
+			expPass:       true,
+			traceResponse: "[{\"result\":{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PU",
 		},
 		{
 			msg: "filtered trace",
@@ -1034,9 +1013,8 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 					EnableMemory:   false,
 				}
 			},
-			expPass:        true,
-			traceResponse:  "[{\"result\":{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PU",
-			expGasConsumed: expGasConsumed,
+			expPass:       true,
+			traceResponse: "[{\"result\":{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PU",
 		},
 		{
 			msg: "javascript tracer",
@@ -1045,9 +1023,8 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 					Tracer: "{data: [], fault: function(log) {}, step: function(log) { if(log.op.toString() == \"CALL\") this.data.push(log.stack.peek(0)); }, result: function() { return this.data; }}",
 				}
 			},
-			expPass:        true,
-			traceResponse:  "[{\"result\":[]}]",
-			expGasConsumed: expGasConsumed,
+			expPass:       true,
+			traceResponse: "[{\"result\":[]}]",
 		},
 		{
 			msg: "default trace with enableFeemarket and filtered return",
@@ -1061,7 +1038,6 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 			expPass:         true,
 			traceResponse:   "[{\"result\":{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PU",
 			enableFeemarket: true,
-			expGasConsumed:  expGasConsumedWithFeeMkt,
 		},
 		{
 			msg: "javascript tracer with enableFeemarket",
@@ -1073,7 +1049,6 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 			expPass:         true,
 			traceResponse:   "[{\"result\":[]}]",
 			enableFeemarket: true,
-			expGasConsumed:  expGasConsumedWithFeeMkt,
 		},
 		{
 			msg: "tracer with multiple transactions",
@@ -1097,7 +1072,6 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 			expPass:         true,
 			traceResponse:   "[{\"result\":{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PU",
 			enableFeemarket: false,
-			expGasConsumed:  expGasConsumed,
 		},
 		{
 			msg: "invalid trace config - Negative Limit",
@@ -1109,8 +1083,7 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 					Limit:          -1,
 				}
 			},
-			expPass:        false,
-			expGasConsumed: 0,
+			expPass: false,
 		},
 		{
 			msg: "invalid trace config - Invalid Tracer",
@@ -1122,9 +1095,8 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 					Tracer:         "invalid_tracer",
 				}
 			},
-			expPass:        true,
-			traceResponse:  "[{\"error\":\"rpc error: code = Internal desc = tracer not found\"}]",
-			expGasConsumed: expGasConsumed,
+			expPass:       true,
+			traceResponse: "[{\"error\":\"rpc error: code = Internal desc = tracer not found\"}]",
 		},
 		{
 			msg: "invalid chain id",
@@ -1133,9 +1105,8 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 				tmp := sdkmath.NewInt(1)
 				chainID = &tmp
 			},
-			expPass:        true,
-			traceResponse:  "[{\"error\":\"rpc error: code = Internal desc = invalid chain id for signer\"}]",
-			expGasConsumed: expGasConsumed,
+			expPass:       true,
+			traceResponse: "[{\"error\":\"rpc error: code = Internal desc = invalid chain id for signer\"}]",
 		},
 	}
 
@@ -1167,7 +1138,7 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 
 			if tc.expPass {
 				suite.Require().NoError(err)
-				// if data is to big, slice the result
+				// if data is too big, slice the result
 				if len(res.Data) > 150 {
 					suite.Require().Equal(tc.traceResponse, string(res.Data[:150]))
 				} else {
@@ -1176,7 +1147,6 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 			} else {
 				suite.Require().Error(err)
 			}
-			suite.Require().Equal(tc.expGasConsumed, suite.ctx.GasMeter().GasConsumed())
 			// Reset for next case
 			chainID = nil
 		})

--- a/x/ibc/transfer/keeper/msg_server.go
+++ b/x/ibc/transfer/keeper/msg_server.go
@@ -2,12 +2,12 @@ package keeper
 
 import (
 	"context"
+	"github.com/EscanBE/evermint/v12/utils"
 	"strings"
 
 	"github.com/armon/go-metrics"
 	"github.com/ethereum/go-ethereum/common"
 
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -31,9 +31,7 @@ func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.
 	transientKVGasCfg := ctx.TransientKVGasConfig()
 
 	// use a zero gas config to avoid extra costs for the relayers
-	ctx = ctx.
-		WithKVGasConfig(storetypes.GasConfig{}).
-		WithTransientKVGasConfig(storetypes.GasConfig{})
+	ctx = utils.UseZeroGasConfig(ctx)
 
 	defer func() {
 		// return the KV gas config to initial values


### PR DESCRIPTION
Problem: tracing txs will run out of gas sometime.
The reason was AnteHandle set gas config to 0 but not in other place where EVM called without setting gas config to zero.