### PR TITLE
fix(deps): bumps ibc-go to v7.4.0 which include patch for ASA-2024-007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#76](https://github.com/EscanBE/evermint/pull/76) Fix wrong Ethereum Tx type when convert to `MsgEthereumTx`
 - (deps) [#106](https://github.com/EscanBE/evermint/pull/106) Bump cosmos-sdk v0.47.8 and ibc v7.3.2
 - (deps) [#114](https://github.com/EscanBE/evermint/pull/114) Bump cosmos-sdk v0.47.10
+- (deps) [#117](https://github.com/EscanBE/evermint/pull/117) Bumps ibc-go to v7.4.0 which include patch for ASA-2024-007
 
 # Evermint changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,23 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 #### Note: Evermint was born for development and research purpose so maintainers do not support migration for new upgrade/breaking changes.
 
+## [v12.2.6] - 2024-04-09
+
+### State Machine Breaking
+
+- (deps) [#116](https://github.com/EscanBE/evermint/pull/116) Bumps ibc-go to v6.3.0 which include patch for ASA-2024-007
+
+## [v12.2.5] - 2024-03-14
+
+### Improvements
+
+- (ante) [#111](https://github.com/EscanBE/evermint/pull/111) Reject EVM txs which having negative value (backport #110)
+- (ante) [#113](https://github.com/EscanBE/evermint/pull/113) Add some validation relates to number range for EVM txs (backport #112)
+
+### Bug Fixes
+
+- (rename-chain) [#109](https://github.com/EscanBE/evermint/pull/109) Resolve compile error `*_test.go` after run rename chain (backport #108)
+
 ## [v12.2.4] - 2024-01-31
 
 ### Improvements

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.47.10
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.4.10
-	github.com/cosmos/ibc-go/v7 v7.3.2
+	github.com/cosmos/ibc-go/v7 v7.4.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/cosmos/gogoproto v1.4.10 h1:QH/yT8X+c0F4ZDacDv3z+xE3WU1P1Z3wQoLMBRJoK
 github.com/cosmos/gogoproto v1.4.10/go.mod h1:3aAZzeRWpAwr+SS/LLkICX2/kDFyaYVzckBDzygIxek=
 github.com/cosmos/iavl v0.20.1 h1:rM1kqeG3/HBT85vsZdoSNsehciqUQPWrR4BYmqE2+zg=
 github.com/cosmos/iavl v0.20.1/go.mod h1:WO7FyvaZJoH65+HFOsDir7xU9FWk2w9cHXNW1XHcl7A=
-github.com/cosmos/ibc-go/v7 v7.3.2 h1:FeUDcBX7VYY0e0iRmcVkPPUjYfAqIc//QuHXo8JHz9c=
-github.com/cosmos/ibc-go/v7 v7.3.2/go.mod h1:IMeOXb7gwpZ+/nOG5BuUkdW4weM1ezvN4PQPws4uzOI=
+github.com/cosmos/ibc-go/v7 v7.4.0 h1:8FqYMptvksgMvlbN4UW9jFxTXzsPyfAzEZurujXac8M=
+github.com/cosmos/ibc-go/v7 v7.4.0/go.mod h1:L/KaEhzV5TGUCTfGysVgMBQtl5Dm7hHitfpk+GIeoAo=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=


### PR DESCRIPTION
For more information:
- [ASA-2024-007](https://github.com/cosmos/ibc-go/security/advisories/GHSA-j496-crgh-34mx)
- [ibc-go v7.4.0 release log](https://github.com/cosmos/ibc-go/releases/tag/v7.4.0)