### PR TITLE
imp(evm): allow one and only one Ethereum Tx per tx execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (feemarket) [#122](https://github.com/EscanBE/evermint/pull/122) Remove unnecessary `x/feemarket` params
 - (evm) [#125](https://github.com/EscanBE/evermint/pull/125) Remove tx fee refunds for EVM txs and min-gas-multiplier logic
 - (feemarket) [#127](https://github.com/EscanBE/evermint/pull/127) Move base fee calculation to end blocker
+- (evm) [#130](https://github.com/EscanBE/evermint/pull/130) Allow one and only one Ethereum Tx per tx execution
 
 ### Bug Fixes
 

--- a/app/ante/evm/eth.go
+++ b/app/ante/evm/eth.go
@@ -54,15 +54,12 @@ func (avd ExternalOwnedAccountVerificationDecorator) AnteHandle(
 
 	var params *evmtypes.Params
 
-	for i, msg := range tx.GetMsgs() {
-		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
-		if !ok {
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
-		}
+	{
+		msgEthTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 
 		txData, err := evmtypes.UnpackTxData(msgEthTx.Data)
 		if err != nil {
-			return ctx, errorsmod.Wrapf(err, "failed to unpack tx data any for tx %d", i)
+			return ctx, errorsmod.Wrap(err, "failed to unpack tx data any for tx")
 		}
 
 		// sender address should be in the tx cache from the previous AnteHandle call
@@ -180,11 +177,8 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	minPriority := int64(math.MaxInt64)
 	baseFee := egcd.evmKeeper.GetBaseFee(ctx, ethCfg)
 
-	for _, msg := range tx.GetMsgs() {
-		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
-		if !ok {
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
-		}
+	{
+		msgEthTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 
 		txData, err := evmtypes.UnpackTxData(msgEthTx.Data)
 		if err != nil {
@@ -278,11 +272,8 @@ func (ctd CanTransferDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 	ethCfg := params.ChainConfig.EthereumConfig(ctd.evmKeeper.ChainID())
 	signer := ethtypes.MakeSigner(ethCfg, big.NewInt(ctx.BlockHeight()))
 
-	for _, msg := range tx.GetMsgs() {
-		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
-		if !ok {
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
-		}
+	{
+		msgEthTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 
 		baseFee := ctd.evmKeeper.GetBaseFee(ctx, ethCfg)
 
@@ -352,11 +343,8 @@ func NewEthIncrementSenderSequenceDecorator(ak evmtypes.AccountKeeper) EthIncrem
 // contract creation, the nonce will be incremented during the transaction execution and not within
 // this AnteHandler decorator.
 func (issd EthIncrementSenderSequenceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	for _, msg := range tx.GetMsgs() {
-		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
-		if !ok {
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
-		}
+	{
+		msgEthTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 
 		txData, err := evmtypes.UnpackTxData(msgEthTx.Data)
 		if err != nil {
@@ -404,11 +392,8 @@ func NewEthBasicValidationDecorator() EthBasicValidationDecorator {
 // AnteHandle handles basic validation for the Ethereum transaction:
 //  1. Value is not negative
 func (bvd EthBasicValidationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	for _, msg := range tx.GetMsgs() {
-		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
-		if !ok {
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
-		}
+	{
+		msgEthTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 
 		txData, err := evmtypes.UnpackTxData(msgEthTx.Data)
 		if err != nil {

--- a/app/ante/evm/fees_test.go
+++ b/app/ante/evm/fees_test.go
@@ -36,11 +36,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 		name     string
 		malleate func() sdk.Tx
 		expPass  bool
+		expPanic bool
 		errMsg   string
 	}{
 		{
-			"invalid tx type",
-			func() sdk.Tx {
+			name: "invalid tx type",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(10)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -48,12 +49,13 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 
 				return &testutiltx.InvalidTx{}
 			},
-			false,
-			"invalid message type",
+			expPass:  false,
+			expPanic: true,
+			errMsg:   "invalid message type",
 		},
 		{
-			"wrong tx type",
-			func() sdk.Tx {
+			name: "wrong tx type",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(10)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -66,24 +68,25 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				txBuilder := suite.CreateTestCosmosTxBuilder(sdkmath.NewInt(0), denom, &testMsg)
 				return txBuilder.GetTx()
 			},
-			false,
-			"invalid message type",
+			expPass:  false,
+			expPanic: true,
+			errMsg:   "invalid message type",
 		},
 		{
-			"valid: invalid tx type with MinGasPrices = 0",
-			func() sdk.Tx {
+			name: "valid: invalid tx type with MinGasPrices = 0",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.ZeroDec()
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
 				suite.Require().NoError(err)
 				return &testutiltx.InvalidTx{}
 			},
-			true,
-			"",
+			expPass: true,
+			errMsg:  "",
 		},
 		{
-			"valid legacy tx with MinGasPrices = 0, gasPrice = 0",
-			func() sdk.Tx {
+			name: "valid legacy tx with MinGasPrices = 0, gasPrice = 0",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.ZeroDec()
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -92,12 +95,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(0), nil, nil, nil)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			true,
-			"",
+			expPass: true,
+			errMsg:  "",
 		},
 		{
-			"valid legacy tx with MinGasPrices = 0, gasPrice > 0",
-			func() sdk.Tx {
+			name: "valid legacy tx with MinGasPrices = 0, gasPrice > 0",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.ZeroDec()
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -106,12 +109,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(10), nil, nil, nil)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			true,
-			"",
+			expPass: true,
+			errMsg:  "",
 		},
 		{
-			"valid legacy tx with MinGasPrices = 10, gasPrice = 10",
-			func() sdk.Tx {
+			name: "valid legacy tx with MinGasPrices = 10, gasPrice = 10",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(10)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -120,12 +123,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(10), nil, nil, nil)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			true,
-			"",
+			expPass: true,
+			errMsg:  "",
 		},
 		{
-			"invalid legacy tx with MinGasPrices = 10, gasPrice = 0",
-			func() sdk.Tx {
+			name: "invalid legacy tx with MinGasPrices = 10, gasPrice = 0",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(10)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -134,12 +137,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(0), nil, nil, nil)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			false,
-			"provided fee < minimum global fee",
+			expPass: false,
+			errMsg:  "provided fee < minimum global fee",
 		},
 		{
-			"valid dynamic tx with MinGasPrices = 0, EffectivePrice = 0",
-			func() sdk.Tx {
+			name: "valid dynamic tx with MinGasPrices = 0, EffectivePrice = 0",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.ZeroDec()
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -148,12 +151,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(0), big.NewInt(0), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			true,
-			"",
+			expPass: true,
+			errMsg:  "",
 		},
 		{
-			"valid dynamic tx with MinGasPrices = 0, EffectivePrice > 0",
-			func() sdk.Tx {
+			name: "valid dynamic tx with MinGasPrices = 0, EffectivePrice > 0",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.ZeroDec()
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -162,12 +165,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(100), big.NewInt(50), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			true,
-			"",
+			expPass: true,
+			errMsg:  "",
 		},
 		{
-			"valid dynamic tx with MinGasPrices < EffectivePrice",
-			func() sdk.Tx {
+			name: "valid dynamic tx with MinGasPrices < EffectivePrice",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(10)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -176,12 +179,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(100), big.NewInt(100), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			true,
-			"",
+			expPass: true,
+			errMsg:  "",
 		},
 		{
-			"invalid dynamic tx with MinGasPrices > EffectivePrice",
-			func() sdk.Tx {
+			name: "invalid dynamic tx with MinGasPrices > EffectivePrice",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(10)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -190,12 +193,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(0), big.NewInt(0), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			false,
-			"provided fee < minimum global fee",
+			expPass: false,
+			errMsg:  "provided fee < minimum global fee",
 		},
 		{
-			"invalid dynamic tx with MinGasPrices > BaseFee, MinGasPrices > EffectivePrice",
-			func() sdk.Tx {
+			name: "invalid dynamic tx with MinGasPrices > BaseFee, MinGasPrices > EffectivePrice",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(100)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -209,12 +212,12 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(1000), big.NewInt(0), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			false,
-			"provided fee < minimum global fee",
+			expPass: false,
+			errMsg:  "provided fee < minimum global fee",
 		},
 		{
-			"valid dynamic tx with MinGasPrices > BaseFee, MinGasPrices < EffectivePrice (big GasTipCap)",
-			func() sdk.Tx {
+			name: "valid dynamic tx with MinGasPrices > BaseFee, MinGasPrices < EffectivePrice (big GasTipCap)",
+			malleate: func() sdk.Tx {
 				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
 				params.MinGasPrice = sdk.NewDec(100)
 				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
@@ -228,8 +231,8 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(1000), big.NewInt(101), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
-			true,
-			"",
+			expPass: true,
+			errMsg:  "",
 		},
 		{
 			name: "do not panic when tx fee overflow of int64",
@@ -286,6 +289,14 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				// s.SetupTest(et.isCheckTx)
 				suite.SetupTest()
 				dec := evmante.NewEthMinGasPriceDecorator(suite.app.FeeMarketKeeper, suite.app.EvmKeeper)
+
+				if tc.expPanic {
+					suite.Require().Panics(func() {
+						_, _ = dec.AnteHandle(suite.ctx, tc.malleate(), et.simulate, testutil.NextFn)
+					})
+					return
+				}
+
 				_, err := dec.AnteHandle(suite.ctx, tc.malleate(), et.simulate, testutil.NextFn)
 
 				if tc.expPass {

--- a/app/ante/evm/setup_ctx.go
+++ b/app/ante/evm/setup_ctx.go
@@ -43,6 +43,28 @@ func (esc EthSetupContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 	return next(newCtx, tx, simulate)
 }
 
+// SingleEthTxDecorator check if the transaction contains one and only one EthereumTx
+type SingleEthTxDecorator struct {
+}
+
+func NewSingleEthTxDecorator() SingleEthTxDecorator {
+	return SingleEthTxDecorator{}
+}
+
+func (sed SingleEthTxDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	for _, msg := range tx.GetMsgs() {
+		if _, isEthTx := msg.(*evmtypes.MsgEthereumTx); !isEthTx {
+			return ctx, errorsmod.Wrapf(errortypes.ErrInvalidRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
+		}
+	}
+
+	if len(tx.GetMsgs()) != 1 {
+		return ctx, errorsmod.Wrapf(errortypes.ErrInvalidRequest, "expected one and only one %T", (*evmtypes.MsgEthereumTx)(nil))
+	}
+
+	return next(ctx, tx, simulate)
+}
+
 // EthEmitEventDecorator emit events in ante handler in case of tx execution failed (out of block gas limit).
 type EthEmitEventDecorator struct {
 	evmKeeper EVMKeeper
@@ -59,18 +81,15 @@ func (eeed EthEmitEventDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 	// we need to emit some basic events at the very end of ante handler to be indexed by tendermint.
 	txIndex := eeed.evmKeeper.GetTxIndexTransient(ctx)
 
-	for i, msg := range tx.GetMsgs() {
-		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
-		if !ok {
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
-		}
+	{
+		msgEthTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 
 		// emit ethereum tx hash as an event so that it can be indexed by Tendermint for query purposes
 		// it's emitted in ante handler, so we can query failed transaction (out of block gas limit).
 		ctx.EventManager().EmitEvent(sdk.NewEvent(
 			evmtypes.EventTypeEthereumTx,
 			sdk.NewAttribute(evmtypes.AttributeKeyEthereumTxHash, msgEthTx.Hash),
-			sdk.NewAttribute(evmtypes.AttributeKeyTxIndex, strconv.FormatUint(txIndex+uint64(i), 10)), // #nosec G701
+			sdk.NewAttribute(evmtypes.AttributeKeyTxIndex, strconv.FormatUint(txIndex, 10)), // #nosec G701
 		))
 	}
 
@@ -146,11 +165,8 @@ func (vbd EthValidateBasicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simu
 	enableCall := evmParams.GetEnableCall()
 	evmDenom := evmParams.GetEvmDenom()
 
-	for _, msg := range protoTx.GetMsgs() {
-		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
-		if !ok {
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
-		}
+	{
+		msgEthTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 
 		// Validate `From` field
 		if msgEthTx.From != "" {

--- a/app/ante/evm/sigverify.go
+++ b/app/ante/evm/sigverify.go
@@ -35,11 +35,8 @@ func (esvd EthSigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, s
 	blockNum := big.NewInt(ctx.BlockHeight())
 	signer := ethtypes.MakeSigner(ethCfg, blockNum)
 
-	for _, msg := range tx.GetMsgs() {
-		msgEthTx, ok := msg.(*evmtypes.MsgEthereumTx)
-		if !ok {
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid message type %T, expected %T", msg, (*evmtypes.MsgEthereumTx)(nil))
-		}
+	{
+		msgEthTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
 
 		allowUnprotectedTxs := evmParams.GetAllowUnprotectedTxs()
 		ethTx := msgEthTx.AsTransaction()

--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -98,6 +98,8 @@ func newEVMAnteHandler(options HandlerOptions) sdk.AnteHandler {
 	return sdk.ChainAnteDecorators(
 		// outermost AnteDecorator. SetUpContext must be called first
 		evmante.NewEthSetUpContextDecorator(options.EvmKeeper),
+		// ensure one and only one evm tx per tx
+		evmante.NewSingleEthTxDecorator(),
 		// Check eth effective gas price against the node's minimal-gas-prices config
 		evmante.NewEthMempoolFeeDecorator(options.EvmKeeper),
 		// Check eth effective gas price against the global MinGasPrice


### PR DESCRIPTION
To simplify coding business logic, add an ante `SingleEthTxDecorator` to check & allow one and only one Ethereum Tx per tx execution.