### PR TITLE
fix(evm): correct block bloom, receipt bloom computation and some other minor issues of transient data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (rename-chain) [#108](https://github.com/EscanBE/evermint/pull/108) Resolve compile error `*_test.go` after run rename chain
 - (proto) [#119](https://github.com/EscanBE/evermint/pull/119) Use `cosmos/gogoproto` in some missed-to-replace places
 - (rpc) [#135](https://github.com/EscanBE/evermint/pull/135) Build tx receipt to response for txs aborted due to block gas limit
+- (evm) [#136](https://github.com/EscanBE/evermint/pull/136) Correct block bloom, receipt bloom computation and some other minor issues of transient data
 
 ### Client Breaking
 

--- a/app/ante/evm/interfaces.go
+++ b/app/ante/evm/interfaces.go
@@ -23,7 +23,7 @@ type EVMKeeper interface { //nolint: revive
 	NewEVM(ctx sdk.Context, msg core.Message, cfg *statedb.EVMConfig, tracer vm.EVMLogger, stateDB vm.StateDB) *vm.EVM
 	DeductTxCostsFromUserBalance(ctx sdk.Context, fees sdk.Coins, from common.Address) error
 	GetBalance(ctx sdk.Context, addr common.Address) *big.Int
-	SetupExecutionContext(ctx sdk.Context, txGas uint64) sdk.Context
+	SetupExecutionContext(ctx sdk.Context, txGas uint64, txType uint8) sdk.Context
 	GetTxCountTransient(ctx sdk.Context) uint64
 	GetParams(ctx sdk.Context) evmtypes.Params
 }

--- a/app/ante/evm/setup_ctx.go
+++ b/app/ante/evm/setup_ctx.go
@@ -105,7 +105,8 @@ func NewEthSetupExecutionDecorator(evmKeeper EVMKeeper) EthSetupExecutionDecorat
 
 // AnteHandle emits some basic events for the eth messages
 func (sed EthSetupExecutionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	sed.evmKeeper.SetupExecutionContext(ctx, tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx).GetGas())
+	ethTx := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx).AsTransaction()
+	sed.evmKeeper.SetupExecutionContext(ctx, ethTx.Gas(), ethTx.Type())
 	return next(ctx, tx, simulate)
 }
 

--- a/rpc/backend/backend_suite_test.go
+++ b/rpc/backend/backend_suite_test.go
@@ -164,12 +164,12 @@ func createTestReceipt(root []byte, resBlock *tmrpctypes.ResultBlock, tx *evmtyp
 
 	transaction := tx.AsTransaction()
 
-	return &ethtypes.Receipt{
+	receipt := &ethtypes.Receipt{
 		Type:              transaction.Type(),
 		PostState:         root,
 		Status:            status,
 		CumulativeGasUsed: gasUsed,
-		Bloom:             ethtypes.BytesToBloom(ethtypes.LogsBloom([]*ethtypes.Log{})),
+		Bloom:             ethtypes.Bloom{}, // compute bellow
 		Logs:              []*ethtypes.Log{},
 		TxHash:            transaction.Hash(),
 		ContractAddress:   common.Address{},
@@ -178,6 +178,10 @@ func createTestReceipt(root []byte, resBlock *tmrpctypes.ResultBlock, tx *evmtyp
 		BlockNumber:       big.NewInt(resBlock.Block.Height),
 		TransactionIndex:  0,
 	}
+
+	receipt.Bloom = ethtypes.CreateBloom(ethtypes.Receipts{receipt})
+
+	return receipt
 }
 
 func (suite *BackendTestSuite) generateTestKeyring(clientDir string) (keyring.Keyring, error) {

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -417,8 +417,8 @@ func (b *Backend) RPCBlockFromTendermintBlock(
 				Type:              transaction.Type(),
 				PostState:         nil,
 				Status:            ethtypes.ReceiptStatusFailed,
-				CumulativeGasUsed: transaction.Gas(),
-				Bloom:             evmtypes.EmptyBlockBloom,
+				CumulativeGasUsed: transaction.Gas(), // compute below
+				Bloom:             ethtypes.Bloom{},  // compute below
 				Logs:              []*ethtypes.Log{},
 				TxHash:            transaction.Hash(),
 				ContractAddress:   common.Address{},
@@ -431,6 +431,8 @@ func (b *Backend) RPCBlockFromTendermintBlock(
 			for _, prevReceipt := range receipts {
 				receipt.CumulativeGasUsed += prevReceipt.GasUsed
 			}
+
+			receipt.Bloom = ethtypes.CreateBloom(ethtypes.Receipts{receipt})
 		} else {
 			icReceipt.Fill(blockHash)
 			receipt = icReceipt.Receipt

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -86,15 +86,27 @@ func UseZeroGasConfig(ctx sdk.Context) sdk.Context {
 	return ctx.WithKVGasConfig(storetypes.GasConfig{}).WithTransientKVGasConfig(storetypes.GasConfig{})
 }
 
-// MoveReceiptStatusToFailed switch state of Ethereum receipt to failed, consensus fields only
+// MoveReceiptStatusToFailed switch state of Ethereum receipt to failed
 func MoveReceiptStatusToFailed(receipt ethtypes.Receipt, existingGasUsed, newGasUsed uint64) ethtypes.Receipt {
 	receiptOfFailed := ethtypes.Receipt{
+		// consensus fields
 		Type:              receipt.Type,
 		PostState:         receipt.PostState,
 		Status:            ethtypes.ReceiptStatusFailed,
 		CumulativeGasUsed: receipt.CumulativeGasUsed - existingGasUsed + newGasUsed,
 		Bloom:             ethtypes.Bloom{}, // compute bellow
 		Logs:              []*ethtypes.Log{},
+
+		// other fields
+
+		// override
+		GasUsed: newGasUsed, // consume all gas
+		// copy others
+		TxHash:           receipt.TxHash,
+		ContractAddress:  receipt.ContractAddress,
+		BlockHash:        receipt.BlockHash,
+		BlockNumber:      receipt.BlockNumber,
+		TransactionIndex: receipt.TransactionIndex,
 	}
 
 	receiptOfFailed.Bloom = ethtypes.CreateBloom(ethtypes.Receipts{&receiptOfFailed})

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -88,12 +88,16 @@ func UseZeroGasConfig(ctx sdk.Context) sdk.Context {
 
 // MoveReceiptStatusToFailed switch state of Ethereum receipt to failed, consensus fields only
 func MoveReceiptStatusToFailed(receipt ethtypes.Receipt, existingGasUsed, newGasUsed uint64) ethtypes.Receipt {
-	return ethtypes.Receipt{
+	receiptOfFailed := ethtypes.Receipt{
 		Type:              receipt.Type,
 		PostState:         receipt.PostState,
 		Status:            ethtypes.ReceiptStatusFailed,
 		CumulativeGasUsed: receipt.CumulativeGasUsed - existingGasUsed + newGasUsed,
-		Bloom:             ethtypes.CreateBloom(ethtypes.Receipts{}),
+		Bloom:             ethtypes.Bloom{}, // compute bellow
 		Logs:              []*ethtypes.Log{},
 	}
+
+	receiptOfFailed.Bloom = ethtypes.CreateBloom(ethtypes.Receipts{&receiptOfFailed})
+
+	return receiptOfFailed
 }

--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"github.com/EscanBE/evermint/v12/utils"
 	abci "github.com/cometbft/cometbft/abci/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -18,10 +19,11 @@ func (k *Keeper) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 // an empty slice.
 func (k *Keeper) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
 	// Gas costs are handled within msg handler so costs should be ignored
-	infCtx := ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+	zeroGasCtx := utils.UseZeroGasConfig(ctx.WithGasMeter(sdk.NewInfiniteGasMeter()))
 
-	bloom := ethtypes.BytesToBloom(k.GetBlockBloomTransient(infCtx).Bytes())
-	k.EmitBlockBloomEvent(infCtx, bloom)
+	receipts := k.GetTxReceiptsTransient(zeroGasCtx)
+	bloom := ethtypes.CreateBloom(receipts)
+	k.EmitBlockBloomEvent(zeroGasCtx, bloom)
 
 	return []abci.ValidatorUpdate{}
 }

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -437,7 +437,7 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 
 		// reset gas meter per transaction to avoid stacking the gas used of every predecessor in the same gas meter
 		ctx = ctx.WithGasMeter(evertypes.NewInfiniteGasMeterWithLimit(msg.Gas()))
-		ctx = k.SetupExecutionContext(ctx, msg.Gas())
+		ctx = k.SetupExecutionContext(ctx, msg.Gas(), ethTx.Type())
 		rsp, err := k.ApplyMessageWithConfig(ctx, msg, types.NewNoOpTracer(), true, cfg, txConfig)
 		if err != nil {
 			continue
@@ -627,7 +627,7 @@ func (k *Keeper) traceTx(
 
 	// reset gas meter per transaction to avoid stacking the gas used of every predecessor in the same gas meter
 	ctx = ctx.WithGasMeter(evertypes.NewInfiniteGasMeterWithLimit(msg.Gas()))
-	ctx = k.SetupExecutionContext(ctx, msg.Gas())
+	ctx = k.SetupExecutionContext(ctx, msg.Gas(), tx.Type())
 	res, err := k.ApplyMessageWithConfig(ctx, msg, tracer, commitMessage, cfg, txConfig)
 	if err != nil {
 		return nil, 0, status.Error(codes.Internal, err.Error())

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -370,14 +370,14 @@ func (k Keeper) GetBaseFee(ctx sdk.Context, ethCfg *params.ChainConfig) *big.Int
 //   - Increase the count of transaction being processed in the current block
 //   - Set the gas used for the current transaction, assume tx failed so gas used = tx gas
 //   - Set the failed receipt for the current transaction, assume tx failed
-func (k Keeper) SetupExecutionContext(ctx sdk.Context, txGas uint64) sdk.Context {
+func (k Keeper) SetupExecutionContext(ctx sdk.Context, txGas uint64, txType uint8) sdk.Context {
 	ctx = utils.UseZeroGasConfig(ctx)
 	k.IncreaseTxCountTransient(ctx)
 	k.SetGasUsedForCurrentTxTransient(ctx, txGas)
 
 	bzFailedReceipt := func() []byte {
 		failedReceipt := &ethtypes.Receipt{
-			Type:              0,
+			Type:              txType,
 			PostState:         nil,
 			Status:            ethtypes.ReceiptStatusFailed,
 			CumulativeGasUsed: k.GetCumulativeLogCountTransient(ctx, false),

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -6,7 +6,6 @@ import (
 	"github.com/EscanBE/evermint/v12/utils"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -138,26 +137,6 @@ func (k Keeper) EmitBlockBloomEvent(ctx sdk.Context, bloom ethtypes.Bloom) {
 // GetAuthority returns the x/evm module authority address
 func (k Keeper) GetAuthority() sdk.AccAddress {
 	return k.authority
-}
-
-// GetBlockBloomTransient returns bloom bytes for the current block height
-func (k Keeper) GetBlockBloomTransient(ctx sdk.Context) *big.Int {
-	store := prefix.NewStore(ctx.TransientStore(k.transientKey), types.KeyPrefixTransientBloom)
-	heightBz := sdk.Uint64ToBigEndian(uint64(ctx.BlockHeight()))
-	bz := store.Get(heightBz)
-	if len(bz) == 0 {
-		return big.NewInt(0)
-	}
-
-	return new(big.Int).SetBytes(bz)
-}
-
-// SetBlockBloomTransient sets the given bloom bytes to the transient store. This value is reset on
-// every block.
-func (k Keeper) SetBlockBloomTransient(ctx sdk.Context, bloom *big.Int) {
-	store := prefix.NewStore(ctx.TransientStore(k.transientKey), types.KeyPrefixTransientBloom)
-	heightBz := sdk.Uint64ToBigEndian(uint64(ctx.BlockHeight()))
-	store.Set(heightBz, bloom.Bytes())
 }
 
 // ----------------------------------------------------------------------------

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -76,6 +76,8 @@ func (k *Keeper) EthereumTx(goCtx context.Context, msg *types.MsgEthereumTx) (*t
 		}
 	}()
 
+	k.SetTxReceiptForCurrentTxTransient(ctx, response.MarshalledReceipt)
+
 	var tmTxHash *tmbytes.HexBytes
 	if len(ctx.TxBytes()) > 0 {
 		tmTxHash = utils.Ptr[tmbytes.HexBytes](tmtypes.Tx(ctx.TxBytes()).Hash())

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -76,8 +76,6 @@ func (k *Keeper) EthereumTx(goCtx context.Context, msg *types.MsgEthereumTx) (*t
 		}
 	}()
 
-	k.SetTxReceiptForCurrentTxTransient(ctx, response.MarshalledReceipt)
-
 	var tmTxHash *tmbytes.HexBytes
 	if len(ctx.TxBytes()) > 0 {
 		tmTxHash = utils.Ptr[tmbytes.HexBytes](tmtypes.Tx(ctx.TxBytes()).Hash())

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -401,7 +401,7 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 		PostState:         nil, // TODO: intermediate state root
 		Status:            0,   // to be filled below
 		CumulativeGasUsed: cumulativeGasUsed,
-		Bloom:             ethtypes.Bloom{}, // to be filled bellow
+		Bloom:             ethtypes.Bloom{}, // compute bellow
 		Logs:              stateDB.Logs(),
 	}
 	if success {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -192,35 +192,35 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, tx *ethtypes.Transaction) (*t
 	}
 
 	if isSuccess() {
-		k.SetGasUsedForCurrentTxTransient(ctx, res.GasUsed)
-	}
-
-	if isSuccess() {
 		// Only call hooks if tx executed successfully.
-		if err = k.PostTxProcessing(tmpCtx, msg, receipt); err != nil {
-			// If hooks return error, revert the whole tx.
-			res.VmError = types.ErrPostTxProcessing.Error()
-			k.Logger(ctx).Error("tx post processing failed", "error", err)
+		if k.hooks != nil {
+			if err = k.PostTxProcessing(tmpCtx, msg, receipt); err != nil {
+				// If hooks return error, revert the whole tx.
+				res.VmError = types.ErrPostTxProcessing.Error()
+				k.Logger(ctx).Error("tx post processing failed", "error", err)
 
-			// If the tx failed in post-processing hooks, we should update receipt and clear the logs
-			newReceipt := utils.MoveReceiptStatusToFailed(*receipt, res.GasUsed, tx.Gas())
-			receipt = &newReceipt
-			k.SetGasUsedForCurrentTxTransient(ctx, tx.Gas())
+				// If the tx failed in post-processing hooks, we should update receipt and clear the logs
+				receipt = utils.Ptr(utils.MoveReceiptStatusToFailed(*receipt, res.GasUsed, tx.Gas()))
+			}
+
+			receipt.Bloom = ethtypes.CreateBloom(ethtypes.Receipts{receipt})
+			bzReceipt, err := receipt.MarshalBinary()
+			if err != nil {
+				return nil, errorsmod.Wrap(err, "failed to marshal receipt")
+			}
+			res.MarshalledReceipt = bzReceipt
+
+			k.SetLogCountForCurrentTxTransient(ctx, uint64(len(receipt.Logs)))
+			k.SetGasUsedForCurrentTxTransient(ctx, receipt.GasUsed)
+			k.SetTxReceiptForCurrentTxTransient(ctx, bzReceipt)
 		}
 
+		// we check the success status again because post-processing can change the status
 		if isSuccess() && commit != nil {
-			// PostTxProcessing is successful, commit the tmpCtx
+			// commit the tmpCtx
 			commit()
 			ctx.EventManager().EmitEvents(tmpCtx.EventManager().Events())
 		}
-
-		// update receipt
-		receipt.Bloom = ethtypes.CreateBloom(ethtypes.Receipts{receipt})
-		bzReceipt, err := receipt.MarshalBinary()
-		if err != nil {
-			return nil, errorsmod.Wrap(err, "failed to marshal receipt")
-		}
-		res.MarshalledReceipt = bzReceipt
 	}
 
 	// reset the gas meter for current cosmos transaction
@@ -409,12 +409,14 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 		}
 	}
 
-	k.SetLogCountForCurrentTxTransient(ctx, uint64(len(receipt.Logs)))
-
 	bzReceipt, err := receipt.MarshalBinary()
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "failed to marshal receipt")
 	}
+
+	k.SetLogCountForCurrentTxTransient(ctx, uint64(len(receipt.Logs)))
+	k.SetGasUsedForCurrentTxTransient(ctx, gasUsed)
+	k.SetTxReceiptForCurrentTxTransient(ctx, bzReceipt)
 
 	return &types.MsgEthereumTxResponse{
 		GasUsed:           gasUsed,

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -223,15 +223,6 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, tx *ethtypes.Transaction) (*t
 		res.MarshalledReceipt = bzReceipt
 	}
 
-	// Update transient block bloom filter
-	if len(receipt.Logs) > 0 {
-		blockBloom := k.GetBlockBloomTransient(ctx)
-		blockBloom.Or(blockBloom, big.NewInt(0).SetBytes(receipt.Bloom.Bytes()))
-
-		// Update transient block bloom filter
-		k.SetBlockBloomTransient(ctx, blockBloom)
-	}
-
 	// reset the gas meter for current cosmos transaction
 	k.ResetGasMeterAndConsumeGas(ctx, res.GasUsed)
 	return res, nil

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -39,6 +39,7 @@ const (
 	prefixTransientTxCount
 	prefixTransientTxGas
 	prefixTransientTxLogCount
+	prefixTransientTxReceipt
 )
 
 // KVStore key prefixes
@@ -54,6 +55,7 @@ var (
 	KeyPrefixTransientBloom      = []byte{prefixTransientBloom}
 	KeyPrefixTransientTxGas      = []byte{prefixTransientTxGas}
 	KeyPrefixTransientTxLogCount = []byte{prefixTransientTxLogCount}
+	KeyPrefixTransientTxReceipt  = []byte{prefixTransientTxReceipt}
 )
 
 // Transient Store key
@@ -77,4 +79,8 @@ func TxGasTransientKey(txIdx uint64) []byte {
 
 func TxLogCountTransientKey(txIdx uint64) []byte {
 	return append(KeyPrefixTransientTxLogCount, sdk.Uint64ToBigEndian(txIdx)...)
+}
+
+func TxReceiptTransientKey(txIdx uint64) []byte {
+	return append(KeyPrefixTransientTxReceipt, sdk.Uint64ToBigEndian(txIdx)...)
 }

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -32,10 +32,10 @@ const (
 
 // prefix bytes for the EVM transient store
 const (
-	prefixTransientBloom   = iota + 1
-	prefixTransientTxIndex // deprecated
-	prefixTransientLogSize // deprecated
-	prefixTransientGasUsed // deprecated
+	prefixTransientBloom   = iota + 1 // deprecated
+	prefixTransientTxIndex            // deprecated
+	prefixTransientLogSize            // deprecated
+	prefixTransientGasUsed            // deprecated
 	prefixTransientTxCount
 	prefixTransientTxGas
 	prefixTransientTxLogCount
@@ -52,7 +52,6 @@ var (
 
 // Transient Store key prefixes
 var (
-	KeyPrefixTransientBloom      = []byte{prefixTransientBloom}
 	KeyPrefixTransientTxGas      = []byte{prefixTransientTxGas}
 	KeyPrefixTransientTxLogCount = []byte{prefixTransientTxLogCount}
 	KeyPrefixTransientTxReceipt  = []byte{prefixTransientTxReceipt}


### PR DESCRIPTION
Closes: #91

This PR contains:
- Fix block bloom computation:
  - Add new transient store to store tx receipt, use it to compute block bloom at the end of block
  - Deprecate legacy block bloom logic and transient store
- Fix receipt bloom computation
- Adjust some transient store call to fix some minor issue