### PR TITLE
imp(evm): improve how block bloom emitted and include bloom to block returned by subscription to filter system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Cosmos-SDK v0.50
 
+### API Breaking
+
+- (evm) [#149](https://github.com/EscanBE/evermint/pull/149) Improve how block bloom emitted and include bloom to block returned by subscription to filter system
+
 ### State Machine Breaking
 
 - (deps) [#148](https://github.com/EscanBE/evermint/pull/148) Bumps Cosmos-SDK v0.50, CometBFT v0.38, IBC v8

--- a/app/app.go
+++ b/app/app.go
@@ -9,35 +9,26 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/EscanBE/evermint/v12/client/docs"
+	"github.com/gorilla/mux"
+	"github.com/spf13/cast"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtos "github.com/cometbft/cometbft/libs/os"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
 	"cosmossdk.io/client/v2/autocli"
 	"cosmossdk.io/core/appmodule"
-
-	runtimeservices "github.com/cosmos/cosmos-sdk/runtime/services"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-
-	"github.com/EscanBE/evermint/v12/utils"
-
-	"github.com/EscanBE/evermint/v12/app/params"
-
-	"github.com/gorilla/mux"
-	"github.com/spf13/cast"
-
 	"cosmossdk.io/log"
-	abci "github.com/cometbft/cometbft/abci/types"
-	cmtos "github.com/cometbft/cometbft/libs/os"
-	sdkdb "github.com/cosmos/cosmos-db"
-
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdkdb "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	runtimeservices "github.com/cosmos/cosmos-sdk/runtime/services"
 	"github.com/cosmos/cosmos-sdk/server/api"
 	srvconfig "github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
@@ -45,13 +36,14 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtxconfig "github.com/cosmos/cosmos-sdk/x/auth/tx/config"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
-	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
 
+	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 	ibctestingtypes "github.com/cosmos/ibc-go/v8/testing/types"
@@ -59,11 +51,15 @@ import (
 	"github.com/EscanBE/evermint/v12/app/ante"
 	ethante "github.com/EscanBE/evermint/v12/app/ante/evm"
 	"github.com/EscanBE/evermint/v12/app/keepers"
+	"github.com/EscanBE/evermint/v12/app/params"
 	"github.com/EscanBE/evermint/v12/app/upgrades"
+	"github.com/EscanBE/evermint/v12/client/docs"
 	"github.com/EscanBE/evermint/v12/constants"
 	"github.com/EscanBE/evermint/v12/ethereum/eip712"
 	srvflags "github.com/EscanBE/evermint/v12/server/flags"
 	evertypes "github.com/EscanBE/evermint/v12/types"
+	"github.com/EscanBE/evermint/v12/utils"
+
 	// Force-load the tracer engines to trigger registration due to Go-Ethereum v1.10.15 changes
 	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native"

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -1,14 +1,15 @@
 package app
 
 import (
-	"github.com/EscanBE/evermint/v12/app/params"
-	cryptocodec "github.com/EscanBE/evermint/v12/crypto/codec"
-	evertypes "github.com/EscanBE/evermint/v12/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/std"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
+
+	"github.com/EscanBE/evermint/v12/app/params"
+	cryptocodec "github.com/EscanBE/evermint/v12/crypto/codec"
+	evertypes "github.com/EscanBE/evermint/v12/types"
 )
 
 func RegisterEncodingConfig() params.EncodingConfig {

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -3,9 +3,10 @@ package upgrades
 import (
 	store "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	"github.com/EscanBE/evermint/v12/app/keepers"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/EscanBE/evermint/v12/app/keepers"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal
@@ -37,6 +38,6 @@ type Fork struct {
 	UpgradeInfo string
 
 	// Function that runs some custom state transition code at the beginning of a fork.
-	// TODO ES: what this for?
+	// TODO: use this
 	BeginForkLogic func(ctx sdk.Context, keepers *keepers.AppKeepers)
 }

--- a/ethereum/eip712/eip712_test.go
+++ b/ethereum/eip712/eip712_test.go
@@ -7,45 +7,42 @@ import (
 	"testing"
 	"time"
 
-	cmdcfg "github.com/EscanBE/evermint/v12/cmd/config"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/stretchr/testify/suite"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 
-	chainapp "github.com/EscanBE/evermint/v12/app"
-	"github.com/EscanBE/evermint/v12/app/helpers"
-	utiltx "github.com/EscanBE/evermint/v12/testutil/tx"
-	"github.com/EscanBE/evermint/v12/utils"
-	feemarkettypes "github.com/EscanBE/evermint/v12/x/feemarket/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	tmversion "github.com/cometbft/cometbft/proto/tendermint/version"
 	"github.com/cometbft/cometbft/version"
-	authtxconfig "github.com/cosmos/cosmos-sdk/x/auth/tx/config"
-
-	"github.com/EscanBE/evermint/v12/app/params"
-	"github.com/EscanBE/evermint/v12/constants"
 
 	sdkmath "cosmossdk.io/math"
-
-	"github.com/EscanBE/evermint/v12/ethereum/eip712"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/signer/core/apitypes"
-	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
-
-	"github.com/EscanBE/evermint/v12/crypto/ethsecp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtxconfig "github.com/cosmos/cosmos-sdk/x/auth/tx/config"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/stretchr/testify/suite"
+
+	chainapp "github.com/EscanBE/evermint/v12/app"
+	"github.com/EscanBE/evermint/v12/app/helpers"
+	"github.com/EscanBE/evermint/v12/app/params"
+	cmdcfg "github.com/EscanBE/evermint/v12/cmd/config"
+	"github.com/EscanBE/evermint/v12/constants"
+	"github.com/EscanBE/evermint/v12/crypto/ethsecp256k1"
+	"github.com/EscanBE/evermint/v12/ethereum/eip712"
+	utiltx "github.com/EscanBE/evermint/v12/testutil/tx"
+	"github.com/EscanBE/evermint/v12/utils"
+	feemarkettypes "github.com/EscanBE/evermint/v12/x/feemarket/types"
 )
 
 // Unit tests for single-signer EIP-712 signature verification. Multi-signature key verification tests are out-of-scope
@@ -175,7 +172,7 @@ func (suite *EIP712TestSuite) TestEIP712() {
 
 	signModes := []signing.SignMode{
 		signing.SignMode_SIGN_MODE_DIRECT,
-		// signing.SignMode_SIGN_MODE_TEXTUAL, // TODO ES: enable?
+		// signing.SignMode_SIGN_MODE_TEXTUAL, // TODO: enable?
 		signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
 	}
 

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"math/big"
@@ -327,7 +328,17 @@ func (b *Backend) BlockBloom(blockRes *cmtrpctypes.ResultBlockResults) ethtypes.
 
 		for _, attr := range event.Attributes {
 			if attr.Key == evmtypes.AttributeKeyEthereumBloom {
-				return ethtypes.BytesToBloom([]byte(attr.Value))
+				bloom := attr.Value
+				if bloom == "" {
+					break
+				}
+
+				bz, err := hex.DecodeString(bloom)
+				if err != nil {
+					b.logger.Debug("failed to decode bloom filter", "bloom", bloom, "error", err.Error())
+					return evmtypes.EmptyBlockBloom
+				}
+				return ethtypes.BytesToBloom(bz)
 			}
 		}
 	}

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math"
 	"math/big"
@@ -321,27 +320,10 @@ func (b *Backend) HeaderByHash(blockHash common.Hash) (*ethtypes.Header, error) 
 
 // BlockBloom query block bloom filter from block results
 func (b *Backend) BlockBloom(blockRes *cmtrpctypes.ResultBlockResults) ethtypes.Bloom {
-	for _, event := range blockRes.FinalizeBlockEvents {
-		if event.Type != evmtypes.EventTypeBlockBloom {
-			continue
-		}
-
-		for _, attr := range event.Attributes {
-			if attr.Key == evmtypes.AttributeKeyEthereumBloom {
-				bloom := attr.Value
-				if bloom == "" {
-					break
-				}
-
-				bz, err := hex.DecodeString(bloom)
-				if err != nil {
-					b.logger.Debug("failed to decode bloom filter", "bloom", bloom, "error", err.Error())
-					return evmtypes.EmptyBlockBloom
-				}
-				return ethtypes.BytesToBloom(bz)
-			}
-		}
+	if bloom := rpctypes.BloomFromEvents(blockRes.FinalizeBlockEvents); bloom != nil {
+		return *bloom
 	}
+
 	return evmtypes.EmptyBlockBloom
 }
 

--- a/rpc/backend/blocks_test.go
+++ b/rpc/backend/blocks_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -937,20 +938,20 @@ func (suite *BackendTestSuite) TestBlockBloom() {
 		expBlockBloom ethtypes.Bloom
 	}{
 		{
-			"empty block result",
-			&cmtrpctypes.ResultBlockResults{},
-			evmtypes.EmptyBlockBloom,
+			name:          "empty block result",
+			blockRes:      &cmtrpctypes.ResultBlockResults{},
+			expBlockBloom: evmtypes.EmptyBlockBloom,
 		},
 		{
-			"non block bloom event type",
-			&cmtrpctypes.ResultBlockResults{
+			name: "non block bloom event type",
+			blockRes: &cmtrpctypes.ResultBlockResults{
 				FinalizeBlockEvents: []abci.Event{{Type: evmtypes.EventTypeEthereumTx}},
 			},
-			evmtypes.EmptyBlockBloom,
+			expBlockBloom: evmtypes.EmptyBlockBloom,
 		},
 		{
-			"nonblock bloom attribute key",
-			&cmtrpctypes.ResultBlockResults{
+			name: "nonblock bloom attribute key",
+			blockRes: &cmtrpctypes.ResultBlockResults{
 				FinalizeBlockEvents: []abci.Event{
 					{
 						Type: evmtypes.EventTypeBlockBloom,
@@ -960,11 +961,11 @@ func (suite *BackendTestSuite) TestBlockBloom() {
 					},
 				},
 			},
-			evmtypes.EmptyBlockBloom,
+			expBlockBloom: evmtypes.EmptyBlockBloom,
 		},
 		{
-			"block bloom attribute key",
-			&cmtrpctypes.ResultBlockResults{
+			name: "block bloom attribute key",
+			blockRes: &cmtrpctypes.ResultBlockResults{
 				FinalizeBlockEvents: []abci.Event{
 					{
 						Type: evmtypes.EventTypeBlockBloom,
@@ -974,7 +975,24 @@ func (suite *BackendTestSuite) TestBlockBloom() {
 					},
 				},
 			},
-			ethtypes.Bloom{},
+			expBlockBloom: evmtypes.EmptyBlockBloom,
+		},
+		{
+			name: "block bloom attribute key and value",
+			blockRes: &cmtrpctypes.ResultBlockResults{
+				FinalizeBlockEvents: []abci.Event{
+					{
+						Type: evmtypes.EventTypeBlockBloom,
+						Attributes: []abci.EventAttribute{
+							{
+								Key:   evmtypes.AttributeKeyEthereumBloom,
+								Value: hex.EncodeToString(ethtypes.BytesToBloom([]byte("test")).Bytes()),
+							},
+						},
+					},
+				},
+			},
+			expBlockBloom: ethtypes.BytesToBloom([]byte("test")),
 		},
 	}
 	for _, tc := range testCases {

--- a/rpc/namespaces/ethereum/eth/filters/api.go
+++ b/rpc/namespaces/ethereum/eth/filters/api.go
@@ -6,20 +6,19 @@ import (
 	"sync"
 	"time"
 
-	"github.com/EscanBE/evermint/v12/rpc/types"
-	"github.com/cosmos/cosmos-sdk/client"
-
-	"cosmossdk.io/log"
-
-	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
-	cmtjrpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
-	cmttypes "github.com/cometbft/cometbft/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	cmtjrpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
+	cmttypes "github.com/cometbft/cometbft/types"
+
+	"cosmossdk.io/log"
+	"github.com/cosmos/cosmos-sdk/client"
+
+	rpctypes "github.com/EscanBE/evermint/v12/rpc/types"
 	evmtypes "github.com/EscanBE/evermint/v12/x/evm/types"
 )
 
@@ -36,8 +35,8 @@ type FilterAPI interface {
 
 // Backend defines the methods requided by the PublicFilterAPI backend
 type Backend interface {
-	GetBlockByNumber(blockNum types.BlockNumber, fullTx bool) (map[string]interface{}, error)
-	HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Header, error)
+	GetBlockByNumber(blockNum rpctypes.BlockNumber, fullTx bool) (map[string]interface{}, error)
+	HeaderByNumber(blockNum rpctypes.BlockNumber) (*ethtypes.Header, error)
 	HeaderByHash(blockHash common.Hash) (*ethtypes.Header, error)
 	CometBFTBlockByHash(hash common.Hash) (*cmtrpctypes.ResultBlock, error)
 	CometBFTBlockResultByNumber(height *int64) (*cmtrpctypes.ResultBlockResults, error)
@@ -338,10 +337,10 @@ func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, er
 					continue
 				}
 
-				baseFee := types.BaseFeeFromEvents(data.ResultFinalizeBlock.Events)
+				baseFee := rpctypes.BaseFeeFromEvents(data.ResultFinalizeBlock.Events)
 
 				// TODO ES: fetch bloom from events
-				header := types.EthHeaderFromCometBFT(data.Block.Header, ethtypes.Bloom{}, baseFee)
+				header := rpctypes.EthHeaderFromCometBFT(data.Block.Header, ethtypes.Bloom{}, baseFee)
 				_ = notifier.Notify(rpcSub.ID, header) // #nosec G703
 			case <-rpcSub.Err():
 				headersSub.Unsubscribe(api.events)

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -129,10 +130,17 @@ func (k Keeper) ChainID() *big.Int {
 
 // EmitBlockBloomEvent emit block bloom events
 func (k Keeper) EmitBlockBloomEvent(ctx sdk.Context, bloom ethtypes.Bloom) {
+	var bloomValue string
+	if bloom.Big().Sign() == 0 {
+		// emit empty string to optimize space since most blocks will have an empty bloom
+		bloomValue = ""
+	} else {
+		bloomValue = hex.EncodeToString(bloom.Bytes())
+	}
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			evmtypes.EventTypeBlockBloom,
-			sdk.NewAttribute(evmtypes.AttributeKeyEthereumBloom, string(bloom.Bytes())),
+			sdk.NewAttribute(evmtypes.AttributeKeyEthereumBloom, bloomValue),
 		),
 	)
 }

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -6,25 +6,23 @@ import (
 	"math"
 	"math/big"
 
-	ethparams "github.com/ethereum/go-ethereum/params"
-
-	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"google.golang.org/protobuf/proto"
 
-	sdkmath "cosmossdk.io/math"
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	ethparams "github.com/ethereum/go-ethereum/params"
 
 	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
-
-	"github.com/ethereum/go-ethereum/core"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 var (
@@ -199,7 +197,6 @@ func (msg *MsgEthereumTx) GetMsgs() []sdk.Msg {
 }
 
 func (msg *MsgEthereumTx) GetMsgsV2() ([]proto.Message, error) {
-	// TODO ES: implement
 	return nil, errors.New("not implemented")
 }
 

--- a/x/evm/types/params_test.go
+++ b/x/evm/types/params_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"testing"
 
 	ethparams "github.com/ethereum/go-ethereum/params"
@@ -126,4 +127,9 @@ func TestIsLondon(t *testing.T) {
 		ethConfig := ethparams.MainnetChainConfig
 		require.Equal(t, IsLondon(ethConfig, tc.height), tc.result)
 	}
+}
+
+func TestEmptyBlockBloom(t *testing.T) {
+	require.Equal(t, ethtypes.Bloom{}.Bytes(), EmptyBlockBloom.Bytes())
+	require.Zero(t, EmptyBlockBloom.Big().Sign())
 }


### PR DESCRIPTION
This PR contains:
- Breaking change!!!: bloom emits at `x/evm.EndBlocker` now emits
  - Hex of bloom if not empty
  - Empty string if bloom is empty
- FIlter system will now returns block bloom along with eth block result