### PR TITLE
fix(evm): adjustment logic of how sender nonce increased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (test) [#150](https://github.com/EscanBE/evermint/pull/150) Improve readability for test
 
+### Bug Fixes
+
+- (evm) [#153](https://github.com/EscanBE/evermint/pull/153) Adjustment logic of how sender nonce increased
+
 ### API Breaking
 
 - (evm) [#149](https://github.com/EscanBE/evermint/pull/149) Improve how block bloom emitted and include bloom to block returned by subscription to filter system

--- a/app/ante/evm/eth.go
+++ b/app/ante/evm/eth.go
@@ -334,12 +334,14 @@ func (ctd CanTransferDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 // EthIncrementSenderSequenceDecorator increments the sequence of the signers.
 type EthIncrementSenderSequenceDecorator struct {
 	ak authkeeper.AccountKeeperI
+	ek EVMKeeper
 }
 
 // NewEthIncrementSenderSequenceDecorator creates a new EthIncrementSenderSequenceDecorator.
-func NewEthIncrementSenderSequenceDecorator(ak authkeeper.AccountKeeperI) EthIncrementSenderSequenceDecorator {
+func NewEthIncrementSenderSequenceDecorator(ak authkeeper.AccountKeeperI, ek EVMKeeper) EthIncrementSenderSequenceDecorator {
 	return EthIncrementSenderSequenceDecorator{
 		ak: ak,
+		ek: ek,
 	}
 }
 
@@ -379,6 +381,7 @@ func (issd EthIncrementSenderSequenceDecorator) AnteHandle(ctx sdk.Context, tx s
 		}
 
 		issd.ak.SetAccount(ctx, acc)
+		issd.ek.SetFlagSenderNonceIncreasedByAnteHandle(ctx, true)
 	}
 
 	return next(ctx, tx, simulate)

--- a/app/ante/evm/interfaces.go
+++ b/app/ante/evm/interfaces.go
@@ -28,7 +28,6 @@ type EVMKeeper interface { //nolint: revive
 	GetParams(ctx sdk.Context) evmtypes.Params
 
 	SetFlagSenderNonceIncreasedByAnteHandle(ctx sdk.Context, increased bool)
-	SetEthTxFeeDeductedByAnteHandle(ctx sdk.Context, coins sdk.Coins)
 }
 
 type FeeMarketKeeper interface {

--- a/app/ante/evm/interfaces.go
+++ b/app/ante/evm/interfaces.go
@@ -26,6 +26,9 @@ type EVMKeeper interface { //nolint: revive
 	SetupExecutionContext(ctx sdk.Context, txGas uint64, txType uint8) sdk.Context
 	GetTxCountTransient(ctx sdk.Context) uint64
 	GetParams(ctx sdk.Context) evmtypes.Params
+
+	SetFlagSenderNonceIncreasedByAnteHandle(ctx sdk.Context, increased bool)
+	SetEthTxFeeDeductedByAnteHandle(ctx sdk.Context, coins sdk.Coins)
 }
 
 type FeeMarketKeeper interface {

--- a/app/ante/evm/setup_ctx.go
+++ b/app/ante/evm/setup_ctx.go
@@ -40,6 +40,10 @@ func (esc EthSetupContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 	newCtx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
 	newCtx = utils.UseZeroGasConfig(newCtx)
 
+	// reset previous run
+	esc.evmKeeper.SetFlagSenderNonceIncreasedByAnteHandle(newCtx, false)
+	esc.evmKeeper.SetEthTxFeeDeductedByAnteHandle(newCtx, nil)
+
 	return next(newCtx, tx, simulate)
 }
 

--- a/app/ante/evm/setup_ctx.go
+++ b/app/ante/evm/setup_ctx.go
@@ -42,7 +42,6 @@ func (esc EthSetupContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 
 	// reset previous run
 	esc.evmKeeper.SetFlagSenderNonceIncreasedByAnteHandle(newCtx, false)
-	esc.evmKeeper.SetEthTxFeeDeductedByAnteHandle(newCtx, nil)
 
 	return next(newCtx, tx, simulate)
 }

--- a/app/ante/evm/setup_ctx_test.go
+++ b/app/ante/evm/setup_ctx_test.go
@@ -1,6 +1,7 @@
 package evm_test
 
 import (
+	"math"
 	"math/big"
 
 	evmante "github.com/EscanBE/evermint/v12/app/ante/evm"
@@ -24,9 +25,10 @@ func (suite *AnteTestSuite) TestEthSetupContextDecorator() {
 	tx := evmtypes.NewTx(ethContractCreationTxParams)
 
 	testCases := []struct {
-		name    string
-		tx      sdk.Tx
-		expPass bool
+		name     string
+		tx       sdk.Tx
+		malleate func()
+		expPass  bool
 	}{
 		{
 			name:    "fail - invalid transaction type - does not implement GasTx",
@@ -38,16 +40,51 @@ func (suite *AnteTestSuite) TestEthSetupContextDecorator() {
 			tx:      tx,
 			expPass: true,
 		},
+		{
+			name: "pass - gas config should be empty",
+			tx:   tx,
+			malleate: func() {
+				suite.ctx = suite.ctx.WithKVGasConfig(storetypes.GasConfig{
+					WriteCostFlat: 1000,
+				})
+				suite.ctx = suite.ctx.WithTransientKVGasConfig(storetypes.GasConfig{
+					WriteCostFlat: 1000,
+				})
+			},
+			expPass: true,
+		},
+		{
+			name: "pass - gas meter should be infinite",
+			tx:   tx,
+			malleate: func() {
+				suite.ctx = suite.ctx.WithGasMeter(storetypes.NewGasMeter(1_000))
+			},
+			expPass: true,
+		},
+		{
+			name: "pass - flag nonce set by ante handle should be removed",
+			tx:   tx,
+			malleate: func() {
+				suite.app.EvmKeeper.SetFlagSenderNonceIncreasedByAnteHandle(suite.ctx, true)
+			},
+			expPass: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			ctx, err := dec.AnteHandle(suite.ctx, tc.tx, false, testutil.NextFn)
+			if tc.malleate != nil {
+				tc.malleate()
+			}
+
+			newCtx, err := dec.AnteHandle(suite.ctx, tc.tx, false, testutil.NextFn)
 
 			if tc.expPass {
 				suite.Require().NoError(err)
-				suite.Equal(storetypes.GasConfig{}, ctx.KVGasConfig())
-				suite.Equal(storetypes.GasConfig{}, ctx.TransientKVGasConfig())
+				suite.Equal(storetypes.GasConfig{}, newCtx.KVGasConfig())
+				suite.Equal(storetypes.GasConfig{}, newCtx.TransientKVGasConfig())
+				suite.Equal(storetypes.Gas(math.MaxUint64), newCtx.GasMeter().GasRemaining())
+				suite.False(suite.app.EvmKeeper.IsSenderNonceIncreasedByAnteHandle(newCtx), "flag must be cleared")
 			} else {
 				suite.Require().Error(err)
 			}

--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -119,7 +119,7 @@ func newEVMAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		evmante.NewEthBasicValidationDecorator(),
 		evmante.NewCanTransferDecorator(options.EvmKeeper),
 		evmante.NewEthGasConsumeDecorator(options.BankKeeper, *options.DistributionKeeper, options.EvmKeeper, *options.StakingKeeper, options.MaxTxGasWanted),
-		evmante.NewEthIncrementSenderSequenceDecorator(options.AccountKeeper),
+		evmante.NewEthIncrementSenderSequenceDecorator(options.AccountKeeper, options.EvmKeeper),
 		evmante.NewEthSetupExecutionDecorator(options.EvmKeeper),
 		// emit eth tx hash and index at the very last ante handler.
 		evmante.NewEthEmitEventDecorator(options.EvmKeeper),

--- a/x/erc20/keeper/evm_test.go
+++ b/x/erc20/keeper/evm_test.go
@@ -170,7 +170,7 @@ func (suite *KeeperTestSuite) TestCallEVMWithData() {
 				contract, err := suite.DeployContract("coin", "token", erc20Decimals)
 				suite.Require().NoError(err)
 				account := utiltx.GenerateAddress()
-				data, _ := erc20.Pack("", account)
+				data, _ := erc20.Pack("unknown", account)
 				return data, &contract
 			},
 			expPass: false,
@@ -238,12 +238,12 @@ func (suite *KeeperTestSuite) TestCallEVMWithData() {
 
 			data, contract := tc.malleate()
 
-			res, err := suite.app.Erc20Keeper.CallEVMWithData(suite.ctx, tc.from, contract, data, true)
+			res, err := suite.app.Erc20Keeper.CallEVMWithData(suite.ctx, tc.from, contract, data, false)
 			if tc.expPass {
-				suite.Require().IsTypef(&evmtypes.MsgEthereumTxResponse{}, res, tc.name)
+				suite.Require().NotNil(res)
 				suite.Require().NoError(err)
 			} else {
-				suite.Require().Error(err)
+				suite.Require().Errorf(err, "result: %v", res)
 			}
 		})
 	}

--- a/x/erc20/keeper/utils_test.go
+++ b/x/erc20/keeper/utils_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"bytes"
 	"encoding/json"
-	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -115,7 +114,7 @@ func (suite *KeeperTestSuite) DoSetupTest() {
 	suite.Require().NoError(err)
 
 	// fund signer acc to pay for tx fees
-	amt := sdkmath.NewInt(int64(math.Pow10(18) * 2))
+	amt := sdkmath.NewInt(2e18)
 	err = testutil.FundAccount(
 		suite.ctx,
 		suite.app.BankKeeper,
@@ -327,6 +326,10 @@ func (suite *KeeperTestSuite) DeployContract(name, symbol string, decimals uint8
 	)
 	suite.ctx = newCtx
 	suite.Commit()
+	if err != nil {
+		suite.NotEqual(common.Address{}, addr)
+		suite.Require().NotNil(suite.app.AccountKeeper.GetAccount(suite.ctx, addr.Bytes()))
+	}
 	return addr, err
 }
 

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -677,9 +677,9 @@ func (suite *EvmTestSuite) TestERC20TransferReverted() {
 			// tx fee should be 100% consumed
 			suite.Require().Equal(new(big.Int).Sub(before, fees[0].Amount.BigInt()), after)
 
-			// nonce should not be increased.
-			nonce2 := k.GetNonce(suite.ctx, suite.from)
-			suite.Require().Equal(nonce, nonce2)
+			// nonce should be increased.
+			nonceLater := k.GetNonce(suite.ctx, suite.from)
+			suite.Require().Equal(nonce+1, nonceLater)
 		})
 	}
 }
@@ -714,10 +714,11 @@ func (suite *EvmTestSuite) TestContractDeploymentRevert() {
 			tx := evmtypes.NewTx(ethTxParams)
 			suite.SignTx(tx)
 
-			// simulate nonce increment in ante handler
+			// simulate nonce increment and flag set in ante handler
 			db := suite.StateDB()
 			db.SetNonce(suite.from, nonce+1)
 			suite.Require().NoError(db.Commit())
+			suite.app.EvmKeeper.SetFlagSenderNonceIncreasedByAnteHandle(suite.ctx, true)
 
 			rsp, err := k.EthereumTx(suite.ctx, tx)
 			suite.Require().NoError(err)

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -277,46 +276,6 @@ func (k Keeper) IsSenderNonceIncreasedByAnteHandle(ctx sdk.Context) bool {
 	store := ctx.TransientStore(k.transientKey)
 	bz := store.Get(evmtypes.KeyTransientFlagIncreasedSenderNonce)
 	return len(bz) > 0 && bz[0] == 1
-}
-
-// SetEthTxFeeDeductedByAnteHandle set the amount of gas fee deducted by AnteHandler.
-func (k Keeper) SetEthTxFeeDeductedByAnteHandle(ctx sdk.Context, coins sdk.Coins) {
-	store := ctx.TransientStore(k.transientKey)
-
-	if coins == nil || coins.IsZero() {
-		store.Delete(evmtypes.KeyTransientFlagDeductedGasFee)
-		return
-	}
-
-	if !coins.IsValid() {
-		panic(fmt.Sprintf("invalid coins: %s", coins))
-	}
-
-	bz, err := coins.MarshalJSON()
-	if err != nil {
-		panic(errorsmod.Wrap(err, "failed to marshal coins"))
-	}
-	store.Set(evmtypes.KeyTransientFlagDeductedGasFee, bz)
-}
-
-// GetEthTxFeeDeductedByAnteHandle returns the amount of gas fee deducted by AnteHandler.
-func (k Keeper) GetEthTxFeeDeductedByAnteHandle(ctx sdk.Context) sdk.Coins {
-	transientStore := ctx.TransientStore(k.transientKey)
-
-	bz := transientStore.Get(evmtypes.KeyTransientFlagDeductedGasFee)
-	if len(bz) == 0 {
-		return nil
-	}
-
-	var coins sdk.Coins
-	if err := json.Unmarshal(bz, &coins); err != nil {
-		panic(errorsmod.Wrap(err, "failed to unmarshal coins"))
-	}
-	if coins.IsZero() || len(coins) != 1 || !coins.IsValid() {
-		panic(fmt.Sprintf("invalid coins: %s", coins))
-	}
-
-	return coins
 }
 
 // ----------------------------------------------------------------------------

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -54,27 +54,6 @@ func (k *Keeper) EthereumTx(goCtx context.Context, msg *evmtypes.MsgEthereumTx) 
 		}
 	}
 
-	/* TODO ES: re-enable this, currently disabled because there was no place buy gas
-	{
-		// TODO ES: add test
-		// restore funds spent for buying gas
-		if deductedFees := k.GetEthTxFeeDeductedByAnteHandle(ctx); !deductedFees.IsZero() {
-			evmDenom := k.GetParams(ctx).EvmDenom
-			coinAmount := deductedFees.AmountOf(k.GetParams(ctx).EvmDenom)
-			if !coinAmount.IsZero() {
-				err := k.bankKeeper.SendCoinsFromModuleToAccount(
-					ctx,
-					authtypes.FeeCollectorName, senderAccAddr,
-					sdk.Coins{sdk.NewCoin(evmDenom, coinAmount)},
-				)
-				if err != nil {
-					panic(errorsmod.Wrapf(err, "failed to restore funds spent for buying gas: %v", err))
-				}
-			}
-		}
-	}
-	*/
-
 	txIndex := k.GetTxCountTransient(ctx) - 1
 
 	labels := []metrics.Label{

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -269,13 +269,9 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 	}
 
 	if contractCreation {
-		// take over the nonce management from evm:
-		// - reset sender's nonce to msg.Nonce() before calling evm.
-		// - increase sender's nonce by one no matter the result.
-		stateDB.SetNonce(sender.Address(), msg.Nonce())
 		ret, _, leftoverGas, vmErr = evm.Create(sender, msg.Data(), leftoverGas, msg.Value())
-		stateDB.SetNonce(sender.Address(), msg.Nonce()+1)
 	} else {
+		stateDB.SetNonce(sender.Address(), msg.Nonce()+1)
 		ret, leftoverGas, vmErr = evm.Call(sender, *msg.To(), msg.Data(), leftoverGas, msg.Value())
 	}
 

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -40,6 +40,8 @@ const (
 	prefixTransientTxGas
 	prefixTransientTxLogCount
 	prefixTransientTxReceipt
+	prefixTransientFlagIncreasedSenderNonce
+	prefixTransientFlagDeductedGasFee
 )
 
 // KVStore key prefixes
@@ -59,7 +61,9 @@ var (
 
 // Transient Store key
 var (
-	KeyTransientTxCount = []byte{prefixTransientTxCount}
+	KeyTransientTxCount                  = []byte{prefixTransientTxCount}
+	KeyTransientFlagIncreasedSenderNonce = []byte{prefixTransientFlagIncreasedSenderNonce}
+	KeyTransientFlagDeductedGasFee       = []byte{prefixTransientFlagDeductedGasFee}
 )
 
 // AddressStoragePrefix returns a prefix to iterate over a given account storage.

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -41,7 +41,6 @@ const (
 	prefixTransientTxLogCount
 	prefixTransientTxReceipt
 	prefixTransientFlagIncreasedSenderNonce
-	prefixTransientFlagDeductedGasFee
 )
 
 // KVStore key prefixes
@@ -63,7 +62,6 @@ var (
 var (
 	KeyTransientTxCount                  = []byte{prefixTransientTxCount}
 	KeyTransientFlagIncreasedSenderNonce = []byte{prefixTransientFlagIncreasedSenderNonce}
-	KeyTransientFlagDeductedGasFee       = []byte{prefixTransientFlagDeductedGasFee}
 )
 
 // AddressStoragePrefix returns a prefix to iterate over a given account storage.


### PR DESCRIPTION
Closes: #152

Adjustment:
- *KEEP:* Nonce still increased by AnteHandle, so if tx fails, the sender nonce still be increased anyway.
- *ADDED:* After nonce increased by AnteHandle, a transient flag will bet set to indicate the sender nonce was increased by AnteHandle
- *ADDED:* When `msg_server` handles the message execution, it will check the flag, if the flag indicate the sender nonce was increased by AnteHandle, it **subtract** the nonce by 1 and reset the flag
- *CHANGED*: nonce increment now follow geth

The flag is needed because the `msg_server.EthereumTx` method will be used for testing purpose and if sender nonce was not increased but it decreased, it no longer correct.