### PR TITLE
imp(evm): refactor `x/evm` state transition code, use go-ethereum code and make usage of `NoBaseFee` flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (test) [#150](https://github.com/EscanBE/evermint/pull/150) Improve readability for test
 - (evm) [#154](https://github.com/EscanBE/evermint/pull/154) Simplify code, force all ETH hardfork enabled
+- (evm) [#156](https://github.com/EscanBE/evermint/pull/156) Refactor `x/evm` state transition code, use go-ethereum code and make usage of `NoBaseFee` flag.
 
 ### Bug Fixes
 

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -194,7 +194,6 @@ func (b *Backend) SetTxDefaults(args evmtypes.TransactionArgs) (evmtypes.Transac
 		return nil
 	}
 
-	// TODO ES: recheck this logic, look like something wrong, are both fields required to be Dynamic fee tx?
 	if args.MaxPriorityFeePerGas != nil && args.MaxFeePerGas != nil {
 		if err := checkRelationMaxPriorityFeePerGasAndMaxFeePerGas(); err != nil {
 			return args, err

--- a/x/erc20/keeper/evm.go
+++ b/x/erc20/keeper/evm.go
@@ -207,7 +207,7 @@ func (k Keeper) CallEVMWithData(
 	)
 
 	// enable NoBaseFee for system call
-	enabled := k.evmKeeper.ShouldEnableNoBaseFee(ctx)
+	enabled := k.evmKeeper.IsNoBaseFeeEnabled(ctx)
 	if !enabled {
 		// enable and restore
 		k.evmKeeper.SetFlagEnableNoBaseFee(ctx, true)

--- a/x/erc20/keeper/evm.go
+++ b/x/erc20/keeper/evm.go
@@ -1,8 +1,11 @@
 package keeper
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"encoding/json"
+	"math/big"
+
+	errorsmod "cosmossdk.io/errors"
+
 	"github.com/EscanBE/evermint/v12/server/config"
 	evmtypes "github.com/EscanBE/evermint/v12/x/evm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"math/big"
 
 	"github.com/EscanBE/evermint/v12/contracts"
 	erc20types "github.com/EscanBE/evermint/v12/x/erc20/types"

--- a/x/erc20/keeper/evm_test.go
+++ b/x/erc20/keeper/evm_test.go
@@ -240,8 +240,8 @@ func (suite *KeeperTestSuite) TestCallEVMWithData() {
 
 			res, err := suite.app.Erc20Keeper.CallEVMWithData(suite.ctx, tc.from, contract, data, false)
 			if tc.expPass {
-				suite.Require().NotNil(res)
 				suite.Require().NoError(err)
+				suite.Require().NotNil(res)
 			} else {
 				suite.Require().Errorf(err, "result: %v", res)
 			}

--- a/x/erc20/keeper/mock_test.go
+++ b/x/erc20/keeper/mock_test.go
@@ -58,7 +58,7 @@ func (m *MockEVMKeeper) SetFlagEnableNoBaseFee(_ sdk.Context, enable bool) {
 	m.noBaseFee = enable
 }
 
-func (m *MockEVMKeeper) ShouldEnableNoBaseFee(_ sdk.Context) bool {
+func (m *MockEVMKeeper) IsNoBaseFeeEnabled(_ sdk.Context) bool {
 	return m.noBaseFee
 }
 

--- a/x/erc20/keeper/mock_test.go
+++ b/x/erc20/keeper/mock_test.go
@@ -21,6 +21,7 @@ var _ erc20types.EVMKeeper = &MockEVMKeeper{}
 
 type MockEVMKeeper struct {
 	mock.Mock
+	noBaseFee bool
 }
 
 func (m *MockEVMKeeper) GetParams(_ sdk.Context) evmtypes.Params {
@@ -51,6 +52,14 @@ func (m *MockEVMKeeper) ApplyMessage(_ sdk.Context, _ core.Message, _ vm.EVMLogg
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*evmtypes.MsgEthereumTxResponse), args.Error(1)
+}
+
+func (m *MockEVMKeeper) SetFlagEnableNoBaseFee(_ sdk.Context, enable bool) {
+	m.noBaseFee = enable
+}
+
+func (m *MockEVMKeeper) ShouldEnableNoBaseFee(_ sdk.Context) bool {
+	return m.noBaseFee
 }
 
 var _ bankkeeper.Keeper = &MockBankKeeper{}

--- a/x/erc20/keeper/msg_server_test.go
+++ b/x/erc20/keeper/msg_server_test.go
@@ -206,7 +206,7 @@ func (suite *KeeperTestSuite) TestConvertCoinNativeCoin() {
 			cosmosBalance := suite.app.BankKeeper.GetBalance(suite.ctx, sender, metadataCoin.Base)
 
 			if tc.expPass {
-				suite.Require().NoError(err, tc.name)
+				suite.Require().NoError(err)
 
 				acc := suite.app.EvmKeeper.GetAccountWithoutBalance(suite.ctx, erc20)
 				if tc.selfdestructed {
@@ -225,7 +225,7 @@ func (suite *KeeperTestSuite) TestConvertCoinNativeCoin() {
 					suite.Require().Equal(balance.(*big.Int).Int64(), big.NewInt(tc.burn).Int64())
 				}
 			} else {
-				suite.Require().Error(err, tc.name)
+				suite.Require().Error(err)
 			}
 		})
 	}

--- a/x/erc20/types/interfaces.go
+++ b/x/erc20/types/interfaces.go
@@ -27,6 +27,8 @@ type EVMKeeper interface {
 	GetAccountWithoutBalance(ctx sdk.Context, addr common.Address) *statedb.Account
 	EstimateGas(c context.Context, req *evmtypes.EthCallRequest) (*evmtypes.EstimateGasResponse, error)
 	ApplyMessage(ctx sdk.Context, msg core.Message, tracer vm.EVMLogger, commit bool) (*evmtypes.MsgEthereumTxResponse, error)
+	SetFlagEnableNoBaseFee(ctx sdk.Context, enable bool)
+	ShouldEnableNoBaseFee(ctx sdk.Context) bool
 }
 
 type (

--- a/x/erc20/types/interfaces.go
+++ b/x/erc20/types/interfaces.go
@@ -28,7 +28,7 @@ type EVMKeeper interface {
 	EstimateGas(c context.Context, req *evmtypes.EthCallRequest) (*evmtypes.EstimateGasResponse, error)
 	ApplyMessage(ctx sdk.Context, msg core.Message, tracer vm.EVMLogger, commit bool) (*evmtypes.MsgEthereumTxResponse, error)
 	SetFlagEnableNoBaseFee(ctx sdk.Context, enable bool)
-	ShouldEnableNoBaseFee(ctx sdk.Context) bool
+	IsNoBaseFeeEnabled(ctx sdk.Context) bool
 }
 
 type (

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -690,6 +690,8 @@ func (suite *EvmTestSuite) TestContractDeploymentRevert() {
 			suite.SetupTest()
 			k := suite.app.EvmKeeper
 
+			k.SetFlagEnableNoBaseFee(suite.ctx, true)
+
 			nonce := k.GetNonce(suite.ctx, suite.from)
 			ctorArgs, err := evmtypes.ERC20Contract.ABI.Pack("", suite.from, big.NewInt(0))
 			suite.Require().NoError(err)

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -2,11 +2,12 @@ package evm_test
 
 import (
 	"fmt"
-	feemarkettypes "github.com/EscanBE/evermint/v12/x/feemarket/types"
-	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"math/big"
 	"testing"
 	"time"
+
+	feemarkettypes "github.com/EscanBE/evermint/v12/x/feemarket/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 
 	storetypes "cosmossdk.io/store/types"
 

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -19,8 +19,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
-	feemarkettypes "github.com/EscanBE/evermint/v12/x/feemarket/types"
-
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -55,8 +53,6 @@ type EvmTestSuite struct {
 	ethSigner ethtypes.Signer
 	from      common.Address
 	to        sdk.AccAddress
-
-	dynamicTxFee bool
 }
 
 // DoSetupTest setup test environment
@@ -75,10 +71,6 @@ func (suite *EvmTestSuite) DoSetupTest() {
 	consAddress := sdk.ConsAddress(priv.PubKey().Address())
 
 	suite.app = helpers.EthSetup(checkTx, func(chainApp *chainapp.Evermint, genesis chainapp.GenesisState) chainapp.GenesisState {
-		if suite.dynamicTxFee { // TODO ES: check this option
-			feemarketGenesis := feemarkettypes.DefaultGenesisState()
-			genesis[feemarkettypes.ModuleName] = chainApp.AppCodec().MustMarshalJSON(feemarketGenesis)
-		}
 		return genesis
 	})
 

--- a/x/evm/keeper/config.go
+++ b/x/evm/keeper/config.go
@@ -54,7 +54,7 @@ func (k Keeper) VMConfig(ctx sdk.Context, cfg *statedb.EVMConfig, tracer vm.EVML
 	return vm.Config{
 		Debug:     debug,
 		Tracer:    tracer,
-		NoBaseFee: cfg.NoBaseFee || k.ShouldEnableNoBaseFee(ctx),
+		NoBaseFee: cfg.NoBaseFee || k.IsNoBaseFeeEnabled(ctx),
 		ExtraEips: cfg.Params.EIPs(),
 	}
 }

--- a/x/evm/keeper/config.go
+++ b/x/evm/keeper/config.go
@@ -28,6 +28,7 @@ func (k *Keeper) EVMConfig(ctx sdk.Context, proposerAddress sdk.ConsAddress, cha
 		ChainConfig: ethCfg,
 		CoinBase:    coinbase,
 		BaseFee:     baseFee.BigInt(),
+		NoBaseFee:   k.IsNoBaseFeeEnabled(ctx),
 	}, nil
 }
 

--- a/x/evm/keeper/config.go
+++ b/x/evm/keeper/config.go
@@ -43,7 +43,7 @@ func (k *Keeper) TxConfig(ctx sdk.Context, txHash common.Hash) statedb.TxConfig 
 
 // VMConfig creates an EVM configuration from the debug setting and the extra EIPs enabled on the
 // module parameters. The config generated uses the default JumpTable from the EVM.
-func (k Keeper) VMConfig(cfg *statedb.EVMConfig, tracer vm.EVMLogger) vm.Config {
+func (k Keeper) VMConfig(ctx sdk.Context, cfg *statedb.EVMConfig, tracer vm.EVMLogger) vm.Config {
 	var debug bool
 	if tracer != nil {
 		if _, ok := tracer.(evmtypes.NoOpTracer); !ok {
@@ -54,7 +54,7 @@ func (k Keeper) VMConfig(cfg *statedb.EVMConfig, tracer vm.EVMLogger) vm.Config 
 	return vm.Config{
 		Debug:     debug,
 		Tracer:    tracer,
-		NoBaseFee: cfg.NoBaseFee,
+		NoBaseFee: cfg.NoBaseFee || k.ShouldEnableNoBaseFee(ctx),
 		ExtraEips: cfg.Params.EIPs(),
 	}
 }

--- a/x/evm/keeper/gas.go
+++ b/x/evm/keeper/gas.go
@@ -6,22 +6,8 @@ import (
 
 // ResetGasMeterAndConsumeGas reset first the gas meter consumed value to zero and set it back to the new value
 // 'gasUsed'
-// TODO ES: remove?
 func (k *Keeper) ResetGasMeterAndConsumeGas(ctx sdk.Context, gasUsed uint64) {
 	// reset the gas count
 	ctx.GasMeter().RefundGas(ctx.GasMeter().GasConsumed(), "reset the gas count")
 	ctx.GasMeter().ConsumeGas(gasUsed, "apply evm transaction")
-}
-
-// GasToRefund calculates the amount of gas the state machine should refund to the sender. It is
-// capped by the refund quotient value.
-// Note: do not pass 0 to refundQuotient
-// TODO ES: remove?
-func GasToRefund(availableRefund, gasConsumed, refundQuotient uint64) uint64 {
-	// Apply refund counter
-	refund := gasConsumed / refundQuotient
-	if refund > availableRefund {
-		return availableRefund
-	}
-	return refund
 }

--- a/x/evm/keeper/gas.go
+++ b/x/evm/keeper/gas.go
@@ -6,6 +6,7 @@ import (
 
 // ResetGasMeterAndConsumeGas reset first the gas meter consumed value to zero and set it back to the new value
 // 'gasUsed'
+// TODO ES: remove?
 func (k *Keeper) ResetGasMeterAndConsumeGas(ctx sdk.Context, gasUsed uint64) {
 	// reset the gas count
 	ctx.GasMeter().RefundGas(ctx.GasMeter().GasConsumed(), "reset the gas count")
@@ -15,6 +16,7 @@ func (k *Keeper) ResetGasMeterAndConsumeGas(ctx sdk.Context, gasUsed uint64) {
 // GasToRefund calculates the amount of gas the state machine should refund to the sender. It is
 // capped by the refund quotient value.
 // Note: do not pass 0 to refundQuotient
+// TODO ES: remove?
 func GasToRefund(availableRefund, gasConsumed, refundQuotient uint64) uint64 {
 	// Apply refund counter
 	refund := gasConsumed / refundQuotient

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -225,6 +225,7 @@ func (k Keeper) EthCall(c context.Context, req *evmtypes.EthCallRequest) (*evmty
 
 	ctx := sdk.UnwrapSDKContext(c)
 	ctx = utils.UseZeroGasConfig(ctx)
+	k.SetFlagEnableNoBaseFee(ctx, true)
 
 	var args evmtypes.TransactionArgs
 	err := json.Unmarshal(req.Args, &args)
@@ -268,6 +269,8 @@ func (k Keeper) EstimateGas(c context.Context, req *evmtypes.EthCallRequest) (*e
 
 	ctx := sdk.UnwrapSDKContext(c)
 	ctx = utils.UseZeroGasConfig(ctx)
+	k.SetFlagEnableNoBaseFee(ctx, true)
+
 	chainID, err := getChainID(ctx, req.ChainId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -411,6 +414,7 @@ func (k Keeper) TraceTx(c context.Context, req *evmtypes.QueryTraceTxRequest) (*
 	ctx = ctx.WithBlockTime(req.BlockTime)
 	ctx = ctx.WithHeaderHash(common.Hex2Bytes(req.BlockHash))
 	ctx = utils.UseZeroGasConfig(ctx)
+	k.SetFlagEnableNoBaseFee(ctx, true)
 
 	// Only the block max gas from the consensus params is needed to calculate base fee
 	ctx = ctx.WithConsensusParams(tmproto.ConsensusParams{
@@ -509,6 +513,7 @@ func (k Keeper) TraceBlock(c context.Context, req *evmtypes.QueryTraceBlockReque
 	ctx = ctx.WithBlockTime(req.BlockTime)
 	ctx = ctx.WithHeaderHash(common.Hex2Bytes(req.BlockHash))
 	ctx = utils.UseZeroGasConfig(ctx)
+	k.SetFlagEnableNoBaseFee(ctx, true)
 
 	// Only the block max gas from the consensus params is needed to calculate base fee
 	ctx = ctx.WithConsensusParams(tmproto.ConsensusParams{

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -265,18 +265,36 @@ func (k Keeper) GetTxReceiptsTransient(ctx sdk.Context) (receipts ethtypes.Recei
 
 // SetFlagSenderNonceIncreasedByAnteHandle sets the flag whether the sender nonce has been increased by AnteHandler.
 func (k Keeper) SetFlagSenderNonceIncreasedByAnteHandle(ctx sdk.Context, increased bool) {
-	store := ctx.TransientStore(k.transientKey)
-	if increased {
-		store.Set(evmtypes.KeyTransientFlagIncreasedSenderNonce, []byte{1})
-	} else {
-		store.Delete(evmtypes.KeyTransientFlagIncreasedSenderNonce)
-	}
+	k.genericSetBoolFlagTransient(ctx, evmtypes.KeyTransientFlagIncreasedSenderNonce, increased)
 }
 
 // IsSenderNonceIncreasedByAnteHandle returns the flag whether the sender nonce has been increased by AnteHandler.
 func (k Keeper) IsSenderNonceIncreasedByAnteHandle(ctx sdk.Context) bool {
+	return k.genericGetBoolFlagTransient(ctx, evmtypes.KeyTransientFlagIncreasedSenderNonce)
+}
+
+// SetFlagEnableNoBaseFee sets the flag whether to enable no-base-fee of EVM config.
+func (k Keeper) SetFlagEnableNoBaseFee(ctx sdk.Context, enable bool) {
+	k.genericSetBoolFlagTransient(ctx, evmtypes.KeyTransientFlagNoBaseFee, enable)
+}
+
+// ShouldEnableNoBaseFee returns the flag should enable no-base-fee of EVM config.
+func (k Keeper) ShouldEnableNoBaseFee(ctx sdk.Context) bool {
+	return k.genericGetBoolFlagTransient(ctx, evmtypes.KeyTransientFlagNoBaseFee)
+}
+
+func (k Keeper) genericSetBoolFlagTransient(ctx sdk.Context, key []byte, value bool) {
 	store := ctx.TransientStore(k.transientKey)
-	bz := store.Get(evmtypes.KeyTransientFlagIncreasedSenderNonce)
+	if value {
+		store.Set(key, []byte{1})
+	} else {
+		store.Delete(key)
+	}
+}
+
+func (k Keeper) genericGetBoolFlagTransient(ctx sdk.Context, key []byte) bool {
+	store := ctx.TransientStore(k.transientKey)
+	bz := store.Get(key)
 	return len(bz) > 0 && bz[0] == 1
 }
 

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -279,8 +279,8 @@ func (k Keeper) SetFlagEnableNoBaseFee(ctx sdk.Context, enable bool) {
 	k.genericSetBoolFlagTransient(ctx, evmtypes.KeyTransientFlagNoBaseFee, enable)
 }
 
-// ShouldEnableNoBaseFee returns the flag should enable no-base-fee of EVM config.
-func (k Keeper) ShouldEnableNoBaseFee(ctx sdk.Context) bool {
+// IsNoBaseFeeEnabled returns the flag if no-base-fee enabled and should be used by EVM config.
+func (k Keeper) IsNoBaseFeeEnabled(ctx sdk.Context) bool {
 	return k.genericGetBoolFlagTransient(ctx, evmtypes.KeyTransientFlagNoBaseFee)
 }
 

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -274,6 +274,7 @@ func (k Keeper) IsSenderNonceIncreasedByAnteHandle(ctx sdk.Context) bool {
 }
 
 // SetFlagEnableNoBaseFee sets the flag whether to enable no-base-fee of EVM config.
+// Go-Ethereum used this setting for `eth_call` and smt like that.
 func (k Keeper) SetFlagEnableNoBaseFee(ctx sdk.Context, enable bool) {
 	k.genericSetBoolFlagTransient(ctx, evmtypes.KeyTransientFlagNoBaseFee, enable)
 }

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -52,7 +52,7 @@ func (k *Keeper) NewEVM(
 	if tracer == nil {
 		tracer = k.Tracer(ctx, msg, cfg.ChainConfig)
 	}
-	vmConfig := k.VMConfig(cfg, tracer)
+	vmConfig := k.VMConfig(ctx, cfg, tracer)
 	return vm.NewEVM(blockCtx, txCtx, stateDB, cfg.ChainConfig, vmConfig)
 }
 

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	ethparams "github.com/ethereum/go-ethereum/params"
 )
 
 // NewEVM generates a go-ethereum VM from the provided Message fields and the chain parameters
@@ -219,11 +218,6 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 	cfg *statedb.EVMConfig,
 	txConfig statedb.TxConfig,
 ) (*evmtypes.MsgEthereumTxResponse, error) {
-	var (
-		ret   []byte // return bytes from evm execution
-		vmErr error  // vm errors do not effect consensus and are therefore not assigned to err
-	)
-
 	// return error if contract creation or call are disabled through governance
 	if !cfg.Params.EnableCreate && msg.To() == nil {
 		return nil, errorsmod.Wrap(evmtypes.ErrCreateDisabled, "failed to create new contract")
@@ -234,70 +228,22 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 	stateDB := statedb.New(ctx, k, txConfig)
 	evm := k.NewEVM(ctx, msg, cfg, tracer, stateDB)
 
-	leftoverGas := msg.Gas()
-
-	// Allow the tracer captures the tx level events, mainly the gas consumption.
-	vmCfg := evm.Config
-	if vmCfg.Debug {
-		vmCfg.Tracer.CaptureTxStart(leftoverGas)
-		defer func() {
-			vmCfg.Tracer.CaptureTxEnd(leftoverGas)
-		}()
+	var gasPool core.GasPool
+	{
+		// in geth, gas pool is block gas, but here we capped it to the gas limit of the message
+		gasPool = core.GasPool(msg.Gas())
 	}
 
-	sender := vm.AccountRef(msg.From())
-	contractCreation := msg.To() == nil
-
-	const homestead = true
-	const istanbul = true
-	intrinsicGas, err := core.IntrinsicGas(msg.Data(), msg.AccessList(), contractCreation, homestead, istanbul)
+	execResult, err := ApplyMessage(evm, msg, &gasPool)
 	if err != nil {
-		// should have already been checked on Ante Handler
-		return nil, errorsmod.Wrap(err, "intrinsic gas failed")
+		return nil, err
 	}
+	gasUsed := execResult.UsedGas
 
-	// Should check again even if it is checked on Ante Handler, because eth_call don't go through Ante Handler.
-	if leftoverGas < intrinsicGas {
-		// eth_estimateGas will check for this exact error
-		return nil, errorsmod.Wrap(core.ErrIntrinsicGas, "apply message")
-	}
-	leftoverGas -= intrinsicGas
-
-	// access list preparation is moved from ante handler to here, because it's needed when `ApplyMessage` is called
-	// under contexts where ante handlers are not run, for example `eth_call` and `eth_estimateGas`.
-	const mergeNetsplit = true
-	rules := cfg.ChainConfig.Rules(big.NewInt(ctx.BlockHeight()), mergeNetsplit)
-	stateDB.PrepareAccessList(msg.From(), msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
-
-	if contractCreation {
-		ret, _, leftoverGas, vmErr = evm.Create(sender, msg.Data(), leftoverGas, msg.Value())
-	} else {
-		stateDB.SetNonce(sender.Address(), msg.Nonce()+1)
-		ret, leftoverGas, vmErr = evm.Call(sender, *msg.To(), msg.Data(), leftoverGas, msg.Value())
-	}
-
-	// After EIP-3529: refunds are capped to gasUsed / 5
-	const refundQuotient = ethparams.RefundQuotientEIP3529
-
-	// calculate gas refund
-	if msg.Gas() < leftoverGas {
-		return nil, errorsmod.Wrap(evmtypes.ErrGasOverflow, "apply message")
-	}
-	// refund gas
-	gasUsed := msg.Gas() - leftoverGas
-	refund := GasToRefund(stateDB.GetRefund(), gasUsed, refundQuotient)
-
-	// update leftoverGas and temporaryGasUsed with refund amount
-	leftoverGas += refund
-	gasUsed -= refund
-
-	var success bool
-	// EVM execution error needs to be available for the JSON-RPC client
-	var vmError string
-	if vmErr != nil {
-		vmError = vmErr.Error()
-	} else {
-		success = true
+	cumulativeGasUsed := gasUsed
+	var prevTxIdx uint64
+	for prevTxIdx = 0; prevTxIdx < uint64(txConfig.TxIndex); prevTxIdx++ {
+		cumulativeGasUsed += k.GetGasUsedForTdxIndexTransient(ctx, prevTxIdx)
 	}
 
 	var txType uint8
@@ -305,12 +251,6 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 		panic("require tx type set")
 	} else {
 		txType = uint8(txConfig.TxType)
-	}
-
-	cumulativeGasUsed := gasUsed
-	var prevTxIdx uint64
-	for prevTxIdx = 0; prevTxIdx < uint64(txConfig.TxIndex); prevTxIdx++ {
-		cumulativeGasUsed += k.GetGasUsedForTdxIndexTransient(ctx, prevTxIdx)
 	}
 
 	receipt := ethtypes.Receipt{
@@ -322,7 +262,7 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 		Bloom:             ethtypes.Bloom{}, // compute bellow
 		Logs:              stateDB.Logs(),
 	}
-	if success {
+	if execResult.Err == nil {
 		receipt.Status = ethtypes.ReceiptStatusSuccessful
 	} else {
 		receipt.Status = ethtypes.ReceiptStatusFailed
@@ -345,10 +285,16 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 	k.SetGasUsedForCurrentTxTransient(ctx, gasUsed)
 	k.SetTxReceiptForCurrentTxTransient(ctx, bzReceipt)
 
+	// EVM execution error needs to be available for the JSON-RPC client
+	var vmError string
+	if execResult.Err != nil {
+		vmError = execResult.Err.Error()
+	}
+
 	return &evmtypes.MsgEthereumTxResponse{
 		GasUsed:           gasUsed,
 		VmError:           vmError,
-		Ret:               ret,
+		Ret:               execResult.ReturnData,
 		Hash:              txConfig.TxHash.Hex(),
 		MarshalledReceipt: bzReceipt,
 	}, nil

--- a/x/evm/keeper/state_transition_core.go
+++ b/x/evm/keeper/state_transition_core.go
@@ -1,0 +1,304 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// This file copied from go-ethereum with some modification
+
+package keeper
+
+import (
+	"fmt"
+	evmtypes "github.com/EscanBE/evermint/v12/x/evm/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"math/big"
+)
+
+/*
+StateTransition Model
+
+A state transition is a change made when a transaction is applied to the current world state
+The state transitioning model does all the necessary work to work out a valid new state root.
+
+1) Nonce handling
+2) Pre pay gas
+3) Create a new state object if the recipient is \0*32
+4) Value transfer
+== If contract creation ==
+
+	4a) Attempt to run transaction data
+	4b) If valid, use result as code for the new state object
+
+== end ==
+5) Run Script section
+6) Derive new state root
+*/
+type StateTransition struct {
+	gp         *core.GasPool
+	msg        core.Message
+	gas        uint64
+	gasPrice   *big.Int
+	gasFeeCap  *big.Int
+	gasTipCap  *big.Int
+	initialGas uint64
+	value      *big.Int
+	data       []byte
+	state      vm.StateDB
+	evm        *vm.EVM
+}
+
+// NewStateTransition initialises and returns a new state transition object.
+func NewStateTransition(evm *vm.EVM, msg core.Message, gp *core.GasPool) *StateTransition {
+	return &StateTransition{
+		gp:        gp,
+		evm:       evm,
+		msg:       msg,
+		gasPrice:  msg.GasPrice(),
+		gasFeeCap: msg.GasFeeCap(),
+		gasTipCap: msg.GasTipCap(),
+		value:     msg.Value(),
+		data:      msg.Data(),
+		state:     evm.StateDB,
+	}
+}
+
+// ApplyMessage computes the new state by applying the given message
+// against the old state within the environment.
+//
+// ApplyMessage returns the bytes returned by any EVM execution (if it took place),
+// the gas used (which includes gas refunds) and an error if it failed. An error always
+// indicates a core error meaning that the message would always fail for that particular
+// state and would never be accepted within a block.
+func ApplyMessage(evm *vm.EVM, msg core.Message, gp *core.GasPool) (*core.ExecutionResult, error) {
+	return NewStateTransition(evm, msg, gp).TransitionDb()
+}
+
+// to returns the recipient of the message.
+func (st *StateTransition) to() common.Address {
+	if st.msg == nil || st.msg.To() == nil /* contract creation */ {
+		return common.Address{}
+	}
+	return *st.msg.To()
+}
+
+func (st *StateTransition) buyGas() error {
+	/* This logic was disabled because AnteHandle already charges the fee
+	// TODO ES: try to let this work
+	mgval := new(big.Int).SetUint64(st.msg.Gas())
+	mgval = mgval.Mul(mgval, st.gasPrice)
+	balanceCheck := mgval
+	if st.gasFeeCap != nil {
+		balanceCheck = new(big.Int).SetUint64(st.msg.Gas())
+		balanceCheck = balanceCheck.Mul(balanceCheck, st.gasFeeCap)
+		balanceCheck.Add(balanceCheck, st.value)
+	}
+	if have, want := st.state.GetBalance(st.msg.From()), balanceCheck; have.Cmp(want) < 0 {
+		return fmt.Errorf("%w: address %v have %v want %v", core.ErrInsufficientFunds, st.msg.From().Hex(), have, want)
+	}
+	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
+		return err
+	}
+	st.gas += st.msg.Gas()
+
+	st.initialGas = st.msg.Gas()
+	st.state.SubBalance(st.msg.From(), mgval)
+	*/
+	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
+		return err
+	}
+	st.initialGas = st.msg.Gas()
+	st.gas += st.msg.Gas()
+	return nil
+}
+
+func (st *StateTransition) preCheck() error {
+	// Only check transactions that are not fake
+	if !st.msg.IsFake() {
+		// Make sure this transaction's nonce is correct.
+		stNonce := st.state.GetNonce(st.msg.From())
+		if msgNonce := st.msg.Nonce(); stNonce < msgNonce {
+			return fmt.Errorf("%w: address %v, tx: %d state: %d", core.ErrNonceTooHigh,
+				st.msg.From().Hex(), msgNonce, stNonce)
+		} else if stNonce > msgNonce {
+			return fmt.Errorf("%w: address %v, tx: %d state: %d", core.ErrNonceTooLow,
+				st.msg.From().Hex(), msgNonce, stNonce)
+		} else if stNonce+1 < stNonce {
+			return fmt.Errorf("%w: address %v, nonce: %d", core.ErrNonceMax,
+				st.msg.From().Hex(), stNonce)
+		}
+		// Make sure the sender is an EOA
+		if codeHash := st.state.GetCodeHash(st.msg.From()); codeHash != common.BytesToHash(evmtypes.EmptyCodeHash) && codeHash != (common.Hash{}) {
+			return fmt.Errorf("%w: address %v, codehash: %s", core.ErrSenderNoEOA,
+				st.msg.From().Hex(), codeHash)
+		}
+	}
+	// Make sure that transaction gasFeeCap is greater than the baseFee (post london)
+	if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
+		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
+		if !st.evm.Config.NoBaseFee || st.gasFeeCap.BitLen() > 0 || st.gasTipCap.BitLen() > 0 {
+			if l := st.gasFeeCap.BitLen(); l > 256 {
+				return fmt.Errorf("%w: address %v, maxFeePerGas bit length: %d", core.ErrFeeCapVeryHigh,
+					st.msg.From().Hex(), l)
+			}
+			if l := st.gasTipCap.BitLen(); l > 256 {
+				return fmt.Errorf("%w: address %v, maxPriorityFeePerGas bit length: %d", core.ErrTipVeryHigh,
+					st.msg.From().Hex(), l)
+			}
+			if st.gasFeeCap.Cmp(st.gasTipCap) < 0 {
+				return fmt.Errorf("%w: address %v, maxPriorityFeePerGas: %s, maxFeePerGas: %s", core.ErrTipAboveFeeCap,
+					st.msg.From().Hex(), st.gasTipCap, st.gasFeeCap)
+			}
+			// This will panic if baseFee is nil, but basefee presence is verified
+			// as part of header validation.
+			if st.gasFeeCap.Cmp(st.evm.Context.BaseFee) < 0 {
+				return fmt.Errorf("%w: address %v, maxFeePerGas: %s baseFee: %s", core.ErrFeeCapTooLow,
+					st.msg.From().Hex(), st.gasFeeCap, st.evm.Context.BaseFee)
+			}
+		}
+	}
+	return st.buyGas()
+}
+
+// TransitionDb will transition the state by applying the current message and
+// returning the evm execution result with following fields.
+//
+//   - used gas:
+//     total gas used (including gas being refunded)
+//   - returndata:
+//     the returned data from evm
+//   - concrete execution error:
+//     various **EVM** error which aborts the execution,
+//     e.g. ErrOutOfGas, ErrExecutionReverted
+//
+// However if any consensus issue encountered, return the error directly with
+// nil evm execution result.
+func (st *StateTransition) TransitionDb() (*core.ExecutionResult, error) {
+	// First check this message satisfies all consensus rules before
+	// applying the message. The rules include these clauses
+	//
+	// 1. the nonce of the message caller is correct
+	// 2. caller has enough balance to cover transaction fee(gaslimit * gasprice)
+	// 3. the amount of gas required is available in the block
+	// 4. the purchased gas is enough to cover intrinsic usage
+	// 5. there is no overflow when calculating intrinsic gas
+	// 6. caller has enough balance to cover asset transfer for **topmost** call
+
+	// Check clauses 1-3, buy gas if everything is correct
+	if err := st.preCheck(); err != nil {
+		return nil, err
+	}
+
+	if st.evm.Config.Debug {
+		st.evm.Config.Tracer.CaptureTxStart(st.initialGas)
+		defer func() {
+			st.evm.Config.Tracer.CaptureTxEnd(st.gas)
+		}()
+	}
+
+	var (
+		msg              = st.msg
+		sender           = vm.AccountRef(msg.From())
+		rules            = st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber, st.evm.Context.Random != nil)
+		contractCreation = msg.To() == nil
+	)
+
+	// Check clauses 4-5, subtract intrinsic gas if everything is correct
+	gas, err := core.IntrinsicGas(st.data, st.msg.AccessList(), contractCreation, rules.IsHomestead, rules.IsIstanbul)
+	if err != nil {
+		return nil, err
+	}
+	if st.gas < gas {
+		return nil, fmt.Errorf("%w: have %d, want %d", core.ErrIntrinsicGas, st.gas, gas)
+	}
+	st.gas -= gas
+
+	// Check clause 6
+	if msg.Value().Sign() > 0 && !st.evm.Context.CanTransfer(st.state, msg.From(), msg.Value()) {
+		return nil, fmt.Errorf("%w: address %v", core.ErrInsufficientFundsForTransfer, msg.From().Hex())
+	}
+
+	// Set up the initial access list.
+	if rules.IsBerlin {
+		st.state.PrepareAccessList(msg.From(), msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
+	}
+	var (
+		ret   []byte
+		vmerr error // vm errors do not effect consensus and are therefore not assigned to err
+	)
+	if contractCreation {
+		ret, _, st.gas, vmerr = st.evm.Create(sender, st.data, st.gas, st.value)
+	} else {
+		// Increment the nonce for the next transaction
+		st.state.SetNonce(msg.From(), st.state.GetNonce(sender.Address())+1)
+		ret, st.gas, vmerr = st.evm.Call(sender, st.to(), st.data, st.gas, st.value)
+	}
+
+	if !rules.IsLondon {
+		// Before EIP-3529: refunds were capped to gasUsed / 2
+		st.refundGas(params.RefundQuotient)
+	} else {
+		// After EIP-3529: refunds are capped to gasUsed / 5
+		st.refundGas(params.RefundQuotientEIP3529)
+	}
+
+	if st.evm.Config.NoBaseFee && st.gasFeeCap.Sign() == 0 && st.gasTipCap.Sign() == 0 {
+		// Skip fee payment when NoBaseFee is set and the fee fields
+		// are 0. This avoids a negative effectiveTip being applied to
+		// the coinbase when simulating calls.
+	} else {
+		/* This logic was disabled because it was not on Evermint
+		// TODO ES: consider make this work
+
+		effectiveTip := st.gasPrice
+		if rules.IsLondon {
+			effectiveTip = cmath.BigMin(st.gasTipCap, new(big.Int).Sub(st.gasFeeCap, st.evm.Context.BaseFee))
+		}
+
+		fee := new(big.Int).SetUint64(st.gasUsed())
+		fee.Mul(fee, effectiveTip)
+		st.state.AddBalance(st.evm.Context.Coinbase, fee)
+		*/
+	}
+
+	return &core.ExecutionResult{
+		UsedGas:    st.gasUsed(),
+		Err:        vmerr,
+		ReturnData: ret,
+	}, nil
+}
+
+func (st *StateTransition) refundGas(refundQuotient uint64) {
+	// Apply refund counter, capped to a refund quotient
+	refund := st.gasUsed() / refundQuotient
+	if refund > st.state.GetRefund() {
+		refund = st.state.GetRefund()
+	}
+	st.gas += refund
+
+	// Return ETH for remaining gas, exchanged at the original rate.
+	remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), st.gasPrice)
+	st.state.AddBalance(st.msg.From(), remaining)
+
+	// Also return remaining gas to the block gas counter so it is
+	// available for the next transaction.
+	st.gp.AddGas(st.gas)
+}
+
+// gasUsed returns the amount of gas used up by the state transition.
+func (st *StateTransition) gasUsed() uint64 {
+	return st.initialGas - st.gas
+}

--- a/x/evm/keeper/state_transition_core.go
+++ b/x/evm/keeper/state_transition_core.go
@@ -20,12 +20,13 @@ package keeper
 
 import (
 	"fmt"
+	"math/big"
+
 	evmtypes "github.com/EscanBE/evermint/v12/x/evm/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
-	"math/big"
 )
 
 /*

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -240,13 +240,16 @@ func (suite *KeeperTestSuite) TestResetGasMeterAndConsumeGas() {
 }
 
 func (suite *KeeperTestSuite) TestEVMConfig() {
+	suite.app.EvmKeeper.SetFlagEnableNoBaseFee(suite.ctx, true)
+
 	proposerAddress := suite.ctx.BlockHeader().ProposerAddress
 	cfg, err := suite.app.EvmKeeper.EVMConfig(suite.ctx, proposerAddress, big.NewInt(constants.TestnetEIP155ChainId))
 	suite.Require().NoError(err)
-	suite.Require().Equal(evmtypes.DefaultParams(), cfg.Params)
-	suite.Require().Equal(big.NewInt(0), cfg.BaseFee)
-	suite.Require().Equal(suite.address, cfg.CoinBase)
-	suite.Require().Equal(evmtypes.DefaultParams().ChainConfig.EthereumConfig(big.NewInt(constants.TestnetEIP155ChainId)), cfg.ChainConfig)
+	suite.Equal(evmtypes.DefaultParams(), cfg.Params)
+	suite.Equal(big.NewInt(0), cfg.BaseFee)
+	suite.Equal(suite.address, cfg.CoinBase)
+	suite.Equal(evmtypes.DefaultParams().ChainConfig.EthereumConfig(big.NewInt(constants.TestnetEIP155ChainId)), cfg.ChainConfig)
+	suite.True(cfg.NoBaseFee)
 }
 
 func (suite *KeeperTestSuite) TestContractDeployment() {

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -180,66 +180,6 @@ func (suite *KeeperTestSuite) TestGetCoinbaseAddress() {
 	}
 }
 
-func (suite *KeeperTestSuite) TestGasToRefund() {
-	testCases := []struct {
-		name           string
-		gasconsumed    uint64
-		refundQuotient uint64
-		expGasRefund   uint64
-		expPanic       bool
-	}{
-		{
-			name:           "pass - gas refund 5",
-			gasconsumed:    5,
-			refundQuotient: 1,
-			expGasRefund:   5,
-			expPanic:       false,
-		},
-		{
-			name:           "pass - gas refund 10",
-			gasconsumed:    10,
-			refundQuotient: 1,
-			expGasRefund:   10,
-			expPanic:       false,
-		},
-		{
-			name:           "pass - gas refund availableRefund",
-			gasconsumed:    11,
-			refundQuotient: 1,
-			expGasRefund:   10,
-			expPanic:       false,
-		},
-		{
-			name:           "fail - gas refund quotient 0",
-			gasconsumed:    11,
-			refundQuotient: 0,
-			expGasRefund:   0,
-			expPanic:       true,
-		},
-	}
-
-	for _, tc := range testCases {
-		suite.Run(tc.name, func() {
-			suite.mintFeeCollector = true
-			suite.SetupTest() // reset
-			vmdb := suite.StateDB()
-			vmdb.AddRefund(10)
-
-			if tc.expPanic {
-				//nolint:all
-				panicF := func() {
-					evmkeeper.GasToRefund(vmdb.GetRefund(), tc.gasconsumed, tc.refundQuotient)
-				}
-				suite.Require().Panics(panicF)
-			} else {
-				gr := evmkeeper.GasToRefund(vmdb.GetRefund(), tc.gasconsumed, tc.refundQuotient)
-				suite.Require().Equal(tc.expGasRefund, gr)
-			}
-		})
-	}
-	suite.mintFeeCollector = false
-}
-
 func (suite *KeeperTestSuite) TestResetGasMeterAndConsumeGas() {
 	testCases := []struct {
 		name        string

--- a/x/evm/keeper/utils_test.go
+++ b/x/evm/keeper/utils_test.go
@@ -207,3 +207,18 @@ func (suite *KeeperTestSuite) FundDefaultAddress(amount int64) {
 	)
 	suite.Require().NoError(err)
 }
+
+// CreateBackupCtxAndEvmQueryClient creates backup sdk.Context and x/evm Query Client, for tracing simulation purpose.
+func (suite *KeeperTestSuite) CreateBackupCtxAndEvmQueryClient() (sdk.Context, evmtypes.QueryClient) {
+	backupCtx, _ := suite.ctx.CacheContext()
+	queryHelper := baseapp.NewQueryServerTestHelper(backupCtx, suite.app.InterfaceRegistry())
+	evmtypes.RegisterQueryServer(queryHelper, suite.app.EvmKeeper)
+	backupQueryClient := evmtypes.NewQueryClient(queryHelper)
+
+	// warm up
+	_, _ = backupQueryClient.Account(backupCtx, &evmtypes.QueryAccountRequest{
+		Address: suite.address.Hex(),
+	})
+
+	return backupCtx, backupQueryClient
+}

--- a/x/evm/statedb/config.go
+++ b/x/evm/statedb/config.go
@@ -61,5 +61,5 @@ type EVMConfig struct {
 	ChainConfig *ethparams.ChainConfig
 	CoinBase    common.Address
 	BaseFee     *big.Int
-	NoBaseFee   bool // TODO ES: use this
+	NoBaseFee   bool
 }

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -41,6 +41,7 @@ const (
 	prefixTransientTxLogCount
 	prefixTransientTxReceipt
 	prefixTransientFlagIncreasedSenderNonce
+	prefixTransientFlagNoBaseFee
 )
 
 // KVStore key prefixes
@@ -62,6 +63,7 @@ var (
 var (
 	KeyTransientTxCount                  = []byte{prefixTransientTxCount}
 	KeyTransientFlagIncreasedSenderNonce = []byte{prefixTransientFlagIncreasedSenderNonce}
+	KeyTransientFlagNoBaseFee            = []byte{prefixTransientFlagNoBaseFee}
 )
 
 // AddressStoragePrefix returns a prefix to iterate over a given account storage.


### PR DESCRIPTION
To come closer to the original `go-ethereum` implementation, the transition state method of `x/evm` is now reworked with code copied from `go-ethereum`.

This PR contains:
- Refactor state transition as described above.
- Make usage of EVM config NoBaseFee, it should be set to `true` by non-consensus action by `eth_call`, `eth_estimateGas`, test...
- EVM config NoBaseFee also being used for system call to EVM like `x/erc20` deployment or convert coins.