### PR TITLE
fix(ante): fix `NewDynamicFeeChecker`, correct effective gas price calculation and minor improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 - (evm) [#153](https://github.com/EscanBE/evermint/pull/153) Adjustment logic of how sender nonce increased
+- (ante) [#162](https://github.com/EscanBE/evermint/pull/162) Fix `NewDynamicFeeChecker`, correct effective gas price calculation and minor improvement
 
 ### API Breaking
 

--- a/app/ante/evm/eth.go
+++ b/app/ante/evm/eth.go
@@ -206,7 +206,7 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 			),
 		)
 
-		priority := evmutils.EthTxPriority(ethTx)
+		priority := evmutils.EthTxPriority(ethTx, baseFee)
 
 		if priority < minPriority {
 			minPriority = priority

--- a/x/evm/keeper/fees_test.go
+++ b/x/evm/keeper/fees_test.go
@@ -528,10 +528,10 @@ func (suite *KeeperTestSuite) TestVerifyFeeAndDeductTxCostsFromUserBalance() {
 			tx := evmtypes.NewTx(ethTxParams)
 			ethTx := tx.AsTransaction()
 
-			priority := evmutils.EthTxPriority(ethTx)
-			suite.Require().Equal(evmutils.EthTxGasPrice(ethTx).String(), fmt.Sprintf("%d", priority))
-
 			baseFee := suite.app.EvmKeeper.GetBaseFee(suite.ctx)
+			priority := evmutils.EthTxPriority(ethTx, baseFee)
+			suite.Require().Equal(evmutils.EthTxEffectiveGasPrice(ethTx, baseFee).String(), fmt.Sprintf("%d", priority))
+
 			fees, err := evmkeeper.VerifyFee(ethTx, evmtypes.DefaultEVMDenom, baseFee, suite.ctx.IsCheckTx())
 			if tc.expectPassVerify {
 				suite.Require().NoError(err)

--- a/x/evm/utils/ethereum_tx.go
+++ b/x/evm/utils/ethereum_tx.go
@@ -1,10 +1,11 @@
 package utils
 
 import (
+	"math"
 	"math/big"
 
 	sdkmath "cosmossdk.io/math"
-	"github.com/ethereum/go-ethereum/common/math"
+	cmath "github.com/ethereum/go-ethereum/common/math"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -24,7 +25,7 @@ func EthTxFee(tx *ethtypes.Transaction) *big.Int {
 // EthTxEffectiveGasPrice returns the effective gas price for the transaction.
 func EthTxEffectiveGasPrice(tx *ethtypes.Transaction, baseFee sdkmath.Int) *big.Int {
 	if tx.Type() == ethtypes.DynamicFeeTxType {
-		return math.BigMin(add(tx.GasTipCap(), baseFee.BigInt()), tx.GasFeeCap())
+		return cmath.BigMin(add(tx.GasTipCap(), baseFee.BigInt()), tx.GasFeeCap())
 	}
 	return tx.GasPrice()
 }
@@ -35,8 +36,8 @@ func EthTxEffectiveFee(tx *ethtypes.Transaction, baseFee sdkmath.Int) *big.Int {
 }
 
 // EthTxPriority returns the priority of a given Ethereum tx.
-func EthTxPriority(tx *ethtypes.Transaction) (priority int64) {
-	gasPrice := EthTxGasPrice(tx)
+func EthTxPriority(tx *ethtypes.Transaction, baseFee sdkmath.Int) (priority int64) {
+	gasPrice := EthTxEffectiveGasPrice(tx, baseFee)
 
 	priority = math.MaxInt64
 


### PR DESCRIPTION
This PR contains:
- Correct effective gas price, which was gone wrong by #160
- Add check only one fee coin is allowed and enforce denom to be EVM denom