### PR TITLE
feat(ante): simulate EVM txs before accept mempool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 - (ante) [#164](https://github.com/EscanBE/evermint/pull/164) Introduce Dual-Lane AnteHandler
+- (ante) [#165](https://github.com/EscanBE/evermint/pull/165) Simulate EVM txs before accept mempool
 
 ### Improvement
 

--- a/app/antedl/ante.go
+++ b/app/antedl/ante.go
@@ -39,7 +39,8 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 
 			// EVM-only lane
 			evmlane.NewEvmLaneSetupExecutionDecorator(*options.EvmKeeper),
-			evmlane.NewEvmLaneEmitEventDecorator(*options.EvmKeeper), // must be the last effective Ante
+			evmlane.NewEvmLaneEmitEventDecorator(*options.EvmKeeper),                                // must be the last effective Ante
+			evmlane.NewEvmLaneExecWithoutErrorDecorator(*options.AccountKeeper, *options.EvmKeeper), // simulation ante
 
 			// Cosmos-only lane
 			cosmoslane.NewCosmosLaneRejectEthereumMsgsDecorator(),

--- a/app/antedl/evmlane/993e_exec_without_error.go
+++ b/app/antedl/evmlane/993e_exec_without_error.go
@@ -88,12 +88,9 @@ func (ed ELExecWithoutErrorDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 		evm = ed.ek.NewEVM(simulationCtx, ethCoreMsg, evmCfg, evmtypes.NewNoOpTracer(), stateDB)
 	}
 	gasPool := core.GasPool(ethCoreMsg.Gas())
-	execResult, err := evmkeeper.ApplyMessage(evm, ethCoreMsg, &gasPool)
+	_, err = evmkeeper.ApplyMessage(evm, ethCoreMsg, &gasPool)
 	if err != nil {
 		return ctx, errorsmod.Wrap(errors.Join(sdkerrors.ErrLogic, err), "tx simulation execution failed")
-	}
-	if execResult.Err != nil {
-		return ctx, errorsmod.Wrap(errors.Join(sdkerrors.ErrLogic, execResult.Err), "tx simulation execution failed with EVM error")
 	}
 
 	return next(ctx, tx, simulate)

--- a/app/antedl/evmlane/993e_exec_without_error.go
+++ b/app/antedl/evmlane/993e_exec_without_error.go
@@ -1,0 +1,100 @@
+package evmlane
+
+import (
+	"errors"
+
+	errorsmod "cosmossdk.io/errors"
+
+	dlanteutils "github.com/EscanBE/evermint/v12/app/antedl/utils"
+	evmkeeper "github.com/EscanBE/evermint/v12/x/evm/keeper"
+	"github.com/EscanBE/evermint/v12/x/evm/statedb"
+	evmtypes "github.com/EscanBE/evermint/v12/x/evm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+type ELExecWithoutErrorDecorator struct {
+	ak authkeeper.AccountKeeper
+	ek evmkeeper.Keeper
+}
+
+// NewEvmLaneExecWithoutErrorDecorator creates a new ELExecWithoutErrorDecorator.
+// This decorator only executes in (re)check-tx and simulation mode.
+//   - If the input transaction is a Cosmos transaction, it calls next ante handler.
+//   - If the input transaction is an Ethereum transaction, it runs simulate the state transition to ensure tx can be executed.
+func NewEvmLaneExecWithoutErrorDecorator(ak authkeeper.AccountKeeper, ek evmkeeper.Keeper) ELExecWithoutErrorDecorator {
+	return ELExecWithoutErrorDecorator{
+		ak: ak,
+		ek: ek,
+	}
+}
+
+// AnteHandle emits some basic events for the eth messages
+func (ed ELExecWithoutErrorDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	if ctx.IsCheckTx() || ctx.IsReCheckTx() {
+		// allow
+	} else if simulate {
+		// allow
+	} else {
+		return next(ctx, tx, simulate)
+	}
+
+	if !dlanteutils.HasSingleEthereumMessage(tx) {
+		return next(ctx, tx, simulate)
+	}
+
+	baseFee := ed.ek.GetBaseFee(ctx)
+	signer := ethtypes.LatestSignerForChainID(ed.ek.ChainID())
+
+	ethMsg := tx.GetMsgs()[0].(*evmtypes.MsgEthereumTx)
+	ethTx := ethMsg.AsTransaction()
+	ethCoreMsg, err := ethTx.AsMessage(signer, baseFee.BigInt())
+	if err != nil {
+		panic(err) // should be checked by basic validation
+	}
+
+	// create a branched context for simulation
+	simulationCtx, _ := ctx.CacheContext()
+
+	if ed.ek.IsSenderNonceIncreasedByAnteHandle(simulationCtx) {
+		// rollback the nonce which was increased by previous ante handle
+		acc := ed.ak.GetAccount(simulationCtx, ethMsg.GetFrom())
+		err := acc.SetSequence(acc.GetSequence() - 1)
+		if err != nil {
+			panic(err)
+		}
+		ed.ak.SetAccount(simulationCtx, acc)
+		ed.ek.SetFlagSenderNonceIncreasedByAnteHandle(simulationCtx, false)
+	}
+
+	var evm *vm.EVM
+	{ // initialize EVM
+		txConfig := statedb.NewEmptyTxConfig(common.BytesToHash(simulationCtx.HeaderHash()))
+		txConfig = txConfig.WithTxTypeFromMessage(ethCoreMsg)
+		stateDB := statedb.New(simulationCtx, &ed.ek, txConfig)
+		evmParams := ed.ek.GetParams(simulationCtx)
+		evmCfg := &statedb.EVMConfig{
+			Params:      evmParams,
+			ChainConfig: evmParams.ChainConfig.EthereumConfig(ed.ek.ChainID()),
+			CoinBase:    common.Address{},
+			BaseFee:     baseFee.BigInt(),
+			NoBaseFee:   false,
+		}
+		evm = ed.ek.NewEVM(simulationCtx, ethCoreMsg, evmCfg, evmtypes.NewNoOpTracer(), stateDB)
+	}
+	gasPool := core.GasPool(ethCoreMsg.Gas())
+	execResult, err := evmkeeper.ApplyMessage(evm, ethCoreMsg, &gasPool)
+	if err != nil {
+		return ctx, errorsmod.Wrap(errors.Join(sdkerrors.ErrLogic, err), "tx simulation execution failed")
+	}
+	if execResult.Err != nil {
+		return ctx, errorsmod.Wrap(errors.Join(sdkerrors.ErrLogic, execResult.Err), "tx simulation execution failed with EVM error")
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/app/antedl/evmlane/993e_exec_without_error_it_test.go
+++ b/app/antedl/evmlane/993e_exec_without_error_it_test.go
@@ -1,0 +1,174 @@
+package evmlane_test
+
+import (
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/EscanBE/evermint/v12/app/antedl/evmlane"
+	"github.com/EscanBE/evermint/v12/constants"
+	itutiltypes "github.com/EscanBE/evermint/v12/integration_test_util/types"
+)
+
+func (s *ELTestSuite) Test_ELExecWithoutErrorDecorator() {
+	acc1 := s.ATS.CITS.WalletAccounts.Number(1)
+	acc2 := s.ATS.CITS.WalletAccounts.Number(2)
+
+	baseFee := s.BaseFee(s.Ctx())
+
+	acc1Balance := s.App().BankKeeper().GetBalance(s.Ctx(), acc1.GetCosmosAddress(), constants.BaseDenom).Amount
+
+	tests := []struct {
+		name          string
+		checkTx       bool
+		reCheckTx     bool
+		simulation    bool
+		tx            func(ctx sdk.Context) sdk.Tx
+		anteSpec      *itutiltypes.AnteTestSpec
+		decoratorSpec *itutiltypes.AnteTestSpec
+	}{
+		{
+			name:    "pass - single-ETH - checkTx, should allow tx which can execute without error",
+			checkTx: true,
+			tx: func(ctx sdk.Context) sdk.Tx {
+				ctb, err := s.SignEthereumTx(ctx, acc1, &ethtypes.DynamicFeeTx{
+					Nonce:     0,
+					GasFeeCap: baseFee.BigInt(),
+					GasTipCap: big.NewInt(1),
+					Gas:       21000,
+					To:        acc2.GetEthAddressP(),
+					Value:     big.NewInt(1),
+				}, s.TxB())
+				s.Require().NoError(err)
+				return ctb.GetTx()
+			},
+			anteSpec:      ts().WantsSuccess(),
+			decoratorSpec: ts().WantsSuccess(),
+		},
+		{
+			name:      "pass - single-ETH - non-check-tx, should ignore txs which can exec with error",
+			checkTx:   false,
+			reCheckTx: false,
+			tx: func(ctx sdk.Context) sdk.Tx {
+				ctb, err := s.SignEthereumTx(ctx, acc1, &ethtypes.DynamicFeeTx{
+					Nonce:     0,
+					GasFeeCap: baseFee.BigInt(),
+					GasTipCap: big.NewInt(1),
+					Gas:       21000,
+					To:        acc2.GetEthAddressP(),
+					Value:     acc1Balance.AddRaw(1).BigInt(), // send more than have
+				}, s.TxB())
+				s.Require().NoError(err)
+				return ctb.GetTx()
+			},
+			anteSpec:      ts().WantsSuccess(),
+			decoratorSpec: ts().WantsSuccess(),
+		},
+		{
+			name:    "fail - single-ETH - check-tx, should reject txs which can exec with error",
+			checkTx: true,
+			tx: func(ctx sdk.Context) sdk.Tx {
+				ctb, err := s.SignEthereumTx(ctx, acc1, &ethtypes.DynamicFeeTx{
+					Nonce:     0,
+					GasFeeCap: baseFee.BigInt(),
+					GasTipCap: big.NewInt(1),
+					Gas:       21000,
+					To:        acc2.GetEthAddressP(),
+					Value:     acc1Balance.AddRaw(1).BigInt(), // send more than have
+				}, s.TxB())
+				s.Require().NoError(err)
+				return ctb.GetTx()
+			},
+			anteSpec:      ts().WantsErrMsgContains("tx simulation execution failed"),
+			decoratorSpec: ts().WantsErrMsgContains("tx simulation execution failed"),
+		},
+		{
+			name:      "fail - single-ETH - re-check-tx, should reject txs which can exec with error",
+			reCheckTx: true,
+			tx: func(ctx sdk.Context) sdk.Tx {
+				ctb, err := s.SignEthereumTx(ctx, acc1, &ethtypes.DynamicFeeTx{
+					Nonce:     0,
+					GasFeeCap: baseFee.BigInt(),
+					GasTipCap: big.NewInt(1),
+					Gas:       21000,
+					To:        acc2.GetEthAddressP(),
+					Value:     acc1Balance.AddRaw(1).BigInt(), // send more than have
+				}, s.TxB())
+				s.Require().NoError(err)
+				return ctb.GetTx()
+			},
+			anteSpec:      ts().WantsErrMsgContains("tx simulation execution failed"),
+			decoratorSpec: ts().WantsErrMsgContains("tx simulation execution failed"),
+		},
+		{
+			name:       "fail - single-ETH - simulation, should reject txs which can exec with error",
+			simulation: true,
+			tx: func(ctx sdk.Context) sdk.Tx {
+				ctb, err := s.SignEthereumTx(ctx, acc1, &ethtypes.DynamicFeeTx{
+					Nonce:     0,
+					GasFeeCap: baseFee.BigInt(),
+					GasTipCap: big.NewInt(1),
+					Gas:       21000,
+					To:        acc2.GetEthAddressP(),
+					Value:     acc1Balance.AddRaw(1).BigInt(), // send more than have
+				}, s.TxB())
+				s.Require().NoError(err)
+				return ctb.GetTx()
+			},
+			anteSpec:      ts().WantsErrMsgContains("tx simulation execution failed"),
+			decoratorSpec: ts().WantsErrMsgContains("tx simulation execution failed"),
+		},
+		{
+			name:    "pass - single-Cosmos - checkTx, normal tx should pass",
+			checkTx: true,
+			tx: func(ctx sdk.Context) sdk.Tx {
+				tb := s.TxB().SetBankSendMsg(acc1, acc2, 1).SetGasLimit(500_000).BigFeeAmount(1)
+				_, err := s.SignCosmosTx(ctx, acc1, tb)
+				s.Require().NoError(err)
+				return tb.Tx()
+			},
+			anteSpec:      ts().WantsSuccess(),
+			decoratorSpec: ts().WantsSuccess(),
+		},
+		{
+			name:    "fail Ante/pass Decorator - single-Cosmos - checkTx, invalid tx should be ignored by this Ante",
+			checkTx: true,
+			tx: func(ctx sdk.Context) sdk.Tx {
+				tb := s.TxB().SetBankSendMsg(acc1, acc2, 1).SetGasLimit(500_000).BigFeeAmount(1)
+				_, err := s.SignCosmosTx(ctx, acc2 /*sender != signer*/, tb)
+				s.Require().NoError(err)
+				return tb.Tx()
+			},
+			anteSpec:      ts().WantsErrMsgContains("pubKey does not match signer address"),
+			decoratorSpec: ts().WantsSuccess(),
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			cachedCtx, _ := s.Ctx().CacheContext()
+
+			tt.decoratorSpec.WithDecorator(
+				evmlane.NewEvmLaneExecWithoutErrorDecorator(*s.App().AccountKeeper(), *s.App().EvmKeeper()),
+			)
+
+			if tt.reCheckTx {
+				cachedCtx = cachedCtx.WithIsReCheckTx(true)
+			} else if tt.checkTx {
+				cachedCtx = cachedCtx.WithIsCheckTx(true)
+			}
+
+			if tt.simulation {
+				tt.anteSpec = tt.anteSpec.WithSimulateOn()
+				tt.decoratorSpec = tt.decoratorSpec.WithSimulateOn()
+			}
+
+			tx := tt.tx(cachedCtx)
+
+			s.ATS.RunTestSpec(cachedCtx, tx, tt.anteSpec, false)
+
+			s.ATS.RunTestSpec(cachedCtx, tx, tt.decoratorSpec, true)
+		})
+	}
+}

--- a/integration_test_util/demo/integration_test_demo_contract_test.go
+++ b/integration_test_util/demo/integration_test_demo_contract_test.go
@@ -56,9 +56,12 @@ func (suite *DemoTestSuite) Test_Contract_DeployContracts() {
 			_, resDeliver, err = suite.CITS.TxSendEvmTx(suite.Ctx(), deployer, &newContractAddress, nil, data)
 			suite.Require().Error(err)
 			suite.Require().NotNil(resDeliver)
-			suite.NotEmpty(resDeliver.CosmosTxHash)
-			suite.NotEmpty(resDeliver.EthTxHash)
-			suite.NotEmpty(resDeliver.EvmError)
+			{
+				// tx should not be executed because AnteHandle prevented it from execution
+				suite.Empty(resDeliver.CosmosTxHash)
+				suite.Empty(resDeliver.EthTxHash)
+				suite.Empty(resDeliver.EvmError)
+			}
 			suite.Commit()
 		})
 	})

--- a/integration_test_util/demo/integration_test_demo_contract_test.go
+++ b/integration_test_util/demo/integration_test_demo_contract_test.go
@@ -56,12 +56,9 @@ func (suite *DemoTestSuite) Test_Contract_DeployContracts() {
 			_, resDeliver, err = suite.CITS.TxSendEvmTx(suite.Ctx(), deployer, &newContractAddress, nil, data)
 			suite.Require().Error(err)
 			suite.Require().NotNil(resDeliver)
-			{
-				// tx should not be executed because AnteHandle prevented it from execution
-				suite.Empty(resDeliver.CosmosTxHash)
-				suite.Empty(resDeliver.EthTxHash)
-				suite.Empty(resDeliver.EvmError)
-			}
+			suite.NotEmpty(resDeliver.CosmosTxHash)
+			suite.NotEmpty(resDeliver.EthTxHash)
+			suite.NotEmpty(resDeliver.EvmError)
 			suite.Commit()
 		})
 	})


### PR DESCRIPTION
The main purpose is to get rid of bad txs as much as possible, less problem with failed txs.

This decorator only effectives with mempool check (check-tx and re-check-tx context).
For large chains with high through put, can bypass in re-check-tx context (which exec after every commit).