### PR TITLE
fix(evm): prevent refund gas fee if sender wasn't paid for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (evm) [#153](https://github.com/EscanBE/evermint/pull/153) Adjustment logic of how sender nonce increased
 - (ante) [#162](https://github.com/EscanBE/evermint/pull/162) Fix `NewDynamicFeeChecker`, correct effective gas price calculation and minor improvement
+- (evm) [#166](https://github.com/EscanBE/evermint/pull/166) Prevent refund gas fee if sender wasn't paid for it
 
 ### API Breaking
 

--- a/app/antedl/ante.go
+++ b/app/antedl/ante.go
@@ -28,7 +28,7 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 			duallane.NewDualLaneTxTimeoutHeightDecorator(sdkauthante.NewTxTimeoutHeightDecorator()),
 			duallane.NewDualLaneValidateMemoDecorator(sdkauthante.NewValidateMemoDecorator(options.AccountKeeper)),
 			duallane.NewDualLaneConsumeTxSizeGasDecorator(sdkauthante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper)),
-			duallane.NewDualLaneDeductFeeDecorator(sdkauthante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)),
+			duallane.NewDualLaneDeductFeeDecorator(*options.EvmKeeper, sdkauthante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)),
 			duallane.NewDualLaneSetPubKeyDecorator(sdkauthante.NewSetPubKeyDecorator(options.AccountKeeper)), // SetPubKeyDecorator must be called before all signature verification decorators
 			duallane.NewDualLaneValidateSigCountDecorator(sdkauthante.NewValidateSigCountDecorator(options.AccountKeeper)),
 			duallane.NewDualLaneSigGasConsumeDecorator(sdkauthante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer)),

--- a/app/antedl/duallane/01_setup_ctx.go
+++ b/app/antedl/duallane/01_setup_ctx.go
@@ -43,6 +43,7 @@ func (scd DLSetupContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 
 	// reset previous run
 	scd.ek.SetFlagSenderNonceIncreasedByAnteHandle(newCtx, false)
+	scd.ek.SetFlagSenderPaidTxFeeInAnteHandle(newCtx, false)
 
 	return next(newCtx, tx, simulate)
 }

--- a/app/antedl/duallane/01_setup_ctx_it_test.go
+++ b/app/antedl/duallane/01_setup_ctx_it_test.go
@@ -33,6 +33,7 @@ func (s *DLTestSuite) Test_DLSetupContextDecorator() {
 			name: "pass - single-ETH - setup correctly",
 			tx: func(ctx sdk.Context) sdk.Tx {
 				s.App().EvmKeeper().SetFlagSenderNonceIncreasedByAnteHandle(ctx, true)
+				s.App().EvmKeeper().SetFlagSenderPaidTxFeeInAnteHandle(ctx, true)
 
 				ctb, err := s.SignEthereumTx(ctx, acc1, &ethtypes.LegacyTx{
 					Nonce:    0,
@@ -51,6 +52,7 @@ func (s *DLTestSuite) Test_DLSetupContextDecorator() {
 				s.Equal(storetypes.GasConfig{}, ctx.TransientKVGasConfig())
 
 				s.True(s.App().EvmKeeper().IsSenderNonceIncreasedByAnteHandle(ctx), "this flag should be set by another decorator")
+				s.True(s.App().EvmKeeper().IsSenderPaidTxFeeInAnteHandle(ctx), "this flag should be set by another decorator")
 			}),
 			decoratorSpec: ts().OnSuccess(func(ctx sdk.Context, tx sdk.Tx) {
 				s.Equal(uint64(math.MaxUint64), ctx.GasMeter().Limit(), "this decorator should use infinite gas meter")
@@ -58,7 +60,8 @@ func (s *DLTestSuite) Test_DLSetupContextDecorator() {
 				s.Equal(storetypes.GasConfig{}, ctx.KVGasConfig())
 				s.Equal(storetypes.GasConfig{}, ctx.TransientKVGasConfig())
 
-				s.False(s.App().EvmKeeper().IsSenderNonceIncreasedByAnteHandle(ctx))
+				s.False(s.App().EvmKeeper().IsSenderNonceIncreasedByAnteHandle(ctx), "this decorator should reset this flag")
+				s.False(s.App().EvmKeeper().IsSenderPaidTxFeeInAnteHandle(ctx), "this decorator should reset this flag")
 			}),
 		},
 		{

--- a/app/antedl/duallane/07_deduct_fee_it_test.go
+++ b/app/antedl/duallane/07_deduct_fee_it_test.go
@@ -538,7 +538,15 @@ func (s *DLTestSuite) Test_DLDeductFeeDecorator() {
 			}
 
 			tt.decoratorSpec.WithDecorator(
-				duallane.NewDualLaneDeductFeeDecorator(sdkauthante.NewDeductFeeDecorator(s.App().AccountKeeper(), s.App().BankKeeper(), s.App().FeeGrantKeeper(), s.ATS.HandlerOptions.TxFeeChecker)),
+				duallane.NewDualLaneDeductFeeDecorator(
+					*s.App().EvmKeeper(),
+					sdkauthante.NewDeductFeeDecorator(
+						s.App().AccountKeeper(),
+						s.App().BankKeeper(),
+						s.App().FeeGrantKeeper(),
+						s.ATS.HandlerOptions.TxFeeChecker,
+					),
+				),
 			)
 
 			if tt.onSuccess != nil {

--- a/app/antedl/evmlane/993e_exec_without_error.go
+++ b/app/antedl/evmlane/993e_exec_without_error.go
@@ -88,7 +88,9 @@ func (ed ELExecWithoutErrorDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 		evm = ed.ek.NewEVM(simulationCtx, ethCoreMsg, evmCfg, evmtypes.NewNoOpTracer(), stateDB)
 	}
 	gasPool := core.GasPool(ethCoreMsg.Gas())
-	_, err = evmkeeper.ApplyMessage(evm, ethCoreMsg, &gasPool)
+	_, err = evmkeeper.ApplyMessage(evm, ethCoreMsg, &gasPool, func(st *evmkeeper.StateTransition) {
+		st.SenderPaidTheFee = ed.ek.IsSenderPaidTxFeeInAnteHandle(simulationCtx)
+	})
 	if err != nil {
 		return ctx, errorsmod.Wrap(errors.Join(sdkerrors.ErrLogic, err), "tx simulation execution failed")
 	}

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -273,6 +273,22 @@ func (k Keeper) IsSenderNonceIncreasedByAnteHandle(ctx sdk.Context) bool {
 	return k.genericGetBoolFlagTransient(ctx, evmtypes.KeyTransientFlagIncreasedSenderNonce)
 }
 
+// SetFlagSenderPaidTxFeeInAnteHandle sets the flag whether the sender has paid for tx fee, which deducted by AnteHandler.
+// This logic is needed because unlike go-ethereum which send buys gas right before state transition,
+// we deduct fee using Deduct Fee Decorator, So if sender not paid the tx fee,
+// the refund logic will not add balance to the sender account.
+// Because in theory, only transaction going through AnteHandler while system call like `x/erc20` does not.
+func (k Keeper) SetFlagSenderPaidTxFeeInAnteHandle(ctx sdk.Context, paid bool) {
+	k.genericSetBoolFlagTransient(ctx, evmtypes.KeyTransientSenderPaidFee, paid)
+}
+
+// IsSenderPaidTxFeeInAnteHandle returns the flag whether the sender had paid for tx fee in AnteHandler.
+// This is used to prevent adding balance into the sender account during refund mechanism
+// if the sender didn't pay the tx fee.
+func (k Keeper) IsSenderPaidTxFeeInAnteHandle(ctx sdk.Context) bool {
+	return k.genericGetBoolFlagTransient(ctx, evmtypes.KeyTransientSenderPaidFee)
+}
+
 // SetFlagEnableNoBaseFee sets the flag whether to enable no-base-fee of EVM config.
 // Go-Ethereum used this setting for `eth_call` and smt like that.
 func (k Keeper) SetFlagEnableNoBaseFee(ctx sdk.Context, enable bool) {

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -234,7 +234,9 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 		gasPool = core.GasPool(msg.Gas())
 	}
 
-	execResult, err := ApplyMessage(evm, msg, &gasPool)
+	execResult, err := ApplyMessage(evm, msg, &gasPool, func(st *StateTransition) {
+		st.SenderPaidTheFee = k.IsSenderPaidTxFeeInAnteHandle(ctx)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -42,6 +42,7 @@ const (
 	prefixTransientTxReceipt
 	prefixTransientFlagIncreasedSenderNonce
 	prefixTransientFlagNoBaseFee
+	prefixTransientFlagSenderPaidFee
 )
 
 // KVStore key prefixes
@@ -64,6 +65,7 @@ var (
 	KeyTransientTxCount                  = []byte{prefixTransientTxCount}
 	KeyTransientFlagIncreasedSenderNonce = []byte{prefixTransientFlagIncreasedSenderNonce}
 	KeyTransientFlagNoBaseFee            = []byte{prefixTransientFlagNoBaseFee}
+	KeyTransientSenderPaidFee            = []byte{prefixTransientFlagSenderPaidFee}
 )
 
 // AddressStoragePrefix returns a prefix to iterate over a given account storage.


### PR DESCRIPTION
Sometime the EVM call from system like `x/erc20`, the sender didn't paid for the gas fee, so we shouldn't refund them.