### PR TITLE
fix(evm): support 256 blocks for `GetHashFn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#153](https://github.com/EscanBE/evermint/pull/153) Adjustment logic of how sender nonce increased
 - (ante) [#162](https://github.com/EscanBE/evermint/pull/162) Fix `NewDynamicFeeChecker`, correct effective gas price calculation and minor improvement
 - (evm) [#166](https://github.com/EscanBE/evermint/pull/166) Prevent refund gas fee if sender wasn't paid for it
+- (evm) [#169](https://github.com/EscanBE/evermint/pull/169) Support 256 blocks for `GetHashFn`
 
 ### API Breaking
 

--- a/x/erc20/keeper/utils_test.go
+++ b/x/erc20/keeper/utils_test.go
@@ -3,10 +3,11 @@ package keeper_test
 import (
 	"bytes"
 	"encoding/json"
-	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 	"math/big"
 	"strconv"
 	"time"
+
+	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 
 	sdkmath "cosmossdk.io/math"
 

--- a/x/evm/genesis_test.go
+++ b/x/evm/genesis_test.go
@@ -1,8 +1,9 @@
 package evm_test
 
 import (
-	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 	"math/big"
+
+	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -1,10 +1,11 @@
 package evm_test
 
 import (
-	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 	"math/big"
 	"testing"
 	"time"
+
+	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 
 	feemarkettypes "github.com/EscanBE/evermint/v12/x/feemarket/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"

--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -2,15 +2,17 @@ package keeper
 
 import (
 	storetypes "cosmossdk.io/store/types"
-	"github.com/EscanBE/evermint/v12/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/EscanBE/evermint/v12/utils"
 )
 
 // BeginBlock sets the sdk Context and EIP155 chain id to the Keeper.
 func (k *Keeper) BeginBlock(ctx sdk.Context) {
 	k.WithChainID(ctx)
+	k.SetBlockHashForCurrentBlockAndPruneOld(ctx)
 }
 
 // EndBlock also retrieves the bloom filter value from the transient store and commits it to the

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 	"math/big"
 	"time"
+
+	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 
 	errorsmod "cosmossdk.io/errors"
 

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -2,8 +2,9 @@ package keeper_test
 
 import (
 	"encoding/json"
-	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 	"math/big"
+
+	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 
 	storetypes "cosmossdk.io/store/types"
 

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -117,6 +117,9 @@ func (k *Keeper) WithChainID(ctx sdk.Context) {
 
 // ChainID returns the EIP155 chain ID for the EVM context
 func (k Keeper) ChainID() *big.Int {
+	if k.eip155ChainID == nil || k.eip155ChainID.Sign() == 0 {
+		panic("chain ID not set")
+	}
 	return k.eip155ChainID
 }
 

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -123,9 +123,13 @@ func (k Keeper) ChainID() *big.Int {
 	return k.eip155ChainID
 }
 
+// GetAuthority returns the x/evm module authority address
+func (k Keeper) GetAuthority() sdk.AccAddress {
+	return k.authority
+}
+
 // ----------------------------------------------------------------------------
-// Block Bloom
-// Required by Web3 API.
+// Block
 // ----------------------------------------------------------------------------
 
 // EmitBlockBloomEvent emit block bloom events
@@ -145,9 +149,42 @@ func (k Keeper) EmitBlockBloomEvent(ctx sdk.Context, bloom ethtypes.Bloom) {
 	)
 }
 
-// GetAuthority returns the x/evm module authority address
-func (k Keeper) GetAuthority() sdk.AccAddress {
-	return k.authority
+// SetBlockHashForCurrentBlockAndPruneOld stores the block hash of current block into KVStore,
+// and prunes the block hash of the 256th block before the current block.
+func (k Keeper) SetBlockHashForCurrentBlockAndPruneOld(ctx sdk.Context) {
+	height := ctx.BlockHeight()
+	if height == 0 {
+		return
+	}
+
+	store := ctx.KVStore(k.storeKey)
+	key := evmtypes.BlockHashKey(uint64(height))
+	store.Set(key, ctx.HeaderHash())
+
+	heightToPrune := height - 256
+	if heightToPrune > 0 {
+		keyToPrune := evmtypes.BlockHashKey(uint64(heightToPrune))
+		store.Delete(keyToPrune)
+	}
+}
+
+// GetBlockHashByBlockNumber returns the block hash by block number.
+func (k Keeper) GetBlockHashByBlockNumber(ctx sdk.Context, height int64) common.Hash {
+	if height <= 0 {
+		return common.Hash{}
+	}
+
+	store := ctx.KVStore(k.storeKey)
+	key := evmtypes.BlockHashKey(uint64(height))
+
+	bz := store.Get(key)
+	if len(bz) == 0 {
+		if height == ctx.BlockHeight() {
+			panic(fmt.Sprintf("block hash not found for current block %d", height))
+		}
+		return common.Hash{}
+	}
+	return common.BytesToHash(bz)
 }
 
 // ----------------------------------------------------------------------------
@@ -389,6 +426,7 @@ func (k Keeper) GetBaseFee(ctx sdk.Context) sdkmath.Int {
 //   - Set the failed receipt for the current transaction, assume tx failed
 func (k Keeper) SetupExecutionContext(ctx sdk.Context, txGas uint64, txType uint8) sdk.Context {
 	ctx = utils.UseZeroGasConfig(ctx)
+	k.SetBlockHashForCurrentBlockAndPruneOld(ctx)
 	k.IncreaseTxCountTransient(ctx)
 	k.SetGasUsedForCurrentTxTransient(ctx, txGas)
 

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -2,9 +2,10 @@ package keeper_test
 
 import (
 	_ "embed"
+	"math/big"
+
 	"github.com/EscanBE/evermint/v12/testutil"
 	utiltx "github.com/EscanBE/evermint/v12/testutil/tx"
-	"math/big"
 
 	storetypes "cosmossdk.io/store/types"
 

--- a/x/evm/keeper/msg_server_test.go
+++ b/x/evm/keeper/msg_server_test.go
@@ -1,8 +1,9 @@
 package keeper_test
 
 import (
-	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 	"math/big"
+
+	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"

--- a/x/evm/keeper/params.go
+++ b/x/evm/keeper/params.go
@@ -33,5 +33,5 @@ func (k Keeper) SetParams(ctx sdk.Context, params evmtypes.Params) error {
 }
 
 func (k Keeper) GetChainConfig(ctx sdk.Context) *ethparams.ChainConfig {
-	return k.GetParams(ctx).ChainConfig.EthereumConfig(k.eip155ChainID)
+	return k.GetParams(ctx).ChainConfig.EthereumConfig(k.ChainID())
 }

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -147,7 +147,7 @@ func (k Keeper) GetHashFn(ctx sdk.Context) corevm.GetHashFunc {
 //
 // For relevant discussion see: https://github.com/cosmos/cosmos-sdk/discussions/9072
 func (k *Keeper) ApplyTransaction(ctx sdk.Context, tx *ethtypes.Transaction) (*evmtypes.MsgEthereumTxResponse, error) {
-	cfg, err := k.EVMConfig(ctx, sdk.ConsAddress(ctx.BlockHeader().ProposerAddress), k.eip155ChainID)
+	cfg, err := k.EVMConfig(ctx, sdk.ConsAddress(ctx.BlockHeader().ProposerAddress), k.ChainID())
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "failed to load evm config")
 	}
@@ -180,7 +180,7 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, tx *ethtypes.Transaction) (*e
 
 // ApplyMessage calls ApplyMessageWithConfig with an empty TxConfig.
 func (k *Keeper) ApplyMessage(ctx sdk.Context, msg core.Message, tracer corevm.EVMLogger, commit bool) (*evmtypes.MsgEthereumTxResponse, error) {
-	cfg, err := k.EVMConfig(ctx, sdk.ConsAddress(ctx.BlockHeader().ProposerAddress), k.eip155ChainID)
+	cfg, err := k.EVMConfig(ctx, sdk.ConsAddress(ctx.BlockHeader().ProposerAddress), k.ChainID())
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "failed to load evm config")
 	}

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -668,7 +668,7 @@ func (suite *KeeperTestSuite) TestApplyMessage() {
 func (suite *KeeperTestSuite) TestApplyMessageWithConfig() {
 	var (
 		ethTx *ethtypes.Transaction
-		//msg          core.Message
+		// msg          core.Message
 		err          error
 		config       *evmvm.EVMConfig
 		keeperParams evmtypes.Params

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -1,8 +1,9 @@
 package keeper
 
 import (
-	storetypes "cosmossdk.io/store/types"
 	"fmt"
+
+	storetypes "cosmossdk.io/store/types"
 
 	"cosmossdk.io/store/prefix"
 	evmtypes "github.com/EscanBE/evermint/v12/x/evm/types"

--- a/x/evm/keeper/statedb_test.go
+++ b/x/evm/keeper/statedb_test.go
@@ -2,8 +2,9 @@ package keeper_test
 
 import (
 	"fmt"
-	"github.com/EscanBE/evermint/v12/x/evm/vm"
 	"math/big"
+
+	"github.com/EscanBE/evermint/v12/x/evm/vm"
 
 	"cosmossdk.io/store/prefix"
 	"github.com/EscanBE/evermint/v12/crypto/ethsecp256k1"

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -28,6 +28,7 @@ const (
 	prefixStorage
 	prefixParams
 	prefixCodeHash
+	prefixBlockHash
 )
 
 // prefix bytes for the EVM transient store
@@ -47,10 +48,11 @@ const (
 
 // KVStore key prefixes
 var (
-	KeyPrefixCode     = []byte{prefixCode}
-	KeyPrefixStorage  = []byte{prefixStorage}
-	KeyPrefixParams   = []byte{prefixParams}
-	KeyPrefixCodeHash = []byte{prefixCodeHash}
+	KeyPrefixCode      = []byte{prefixCode}
+	KeyPrefixStorage   = []byte{prefixStorage}
+	KeyPrefixParams    = []byte{prefixParams}
+	KeyPrefixCodeHash  = []byte{prefixCodeHash}
+	KeyPrefixBlockHash = []byte{prefixBlockHash}
 )
 
 // Transient Store key prefixes
@@ -76,6 +78,12 @@ func AddressStoragePrefix(address common.Address) []byte {
 // StateKey defines the full key under which an account state is stored.
 func StateKey(address common.Address, key []byte) []byte {
 	return append(AddressStoragePrefix(address), key...)
+}
+
+// BlockHashKey returns the key for the block hash with the given height.
+// Note: only most-recent 256 block hashes are stored.
+func BlockHashKey(height uint64) []byte {
+	return append(KeyPrefixBlockHash, sdk.Uint64ToBigEndian(height)...)
 }
 
 func TxGasTransientKey(txIdx uint64) []byte {

--- a/x/evm/types/storage.go
+++ b/x/evm/types/storage.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Storage represents the account Storage map as a slice of single key value
-// State pairs. This is to prevent non determinism at genesis initialization or export.
+// State pairs. This is to prevent non-determinism at genesis initialization or export.
 type Storage []State
 
 // Validate performs a basic validation of the Storage fields.


### PR DESCRIPTION
According to Ethereum, current block hash + 255 historical block hash are supported by `GetHashFn`.

This PR introduce new store to persist block hash into store, the most recent 256 records are kept and `GetHashFn` retrieves directly from here.