### PR TITLE
fix(app): fix staking hooks not available in some keepers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (ante) [#162](https://github.com/EscanBE/evermint/pull/162) Fix `NewDynamicFeeChecker`, correct effective gas price calculation and minor improvement
 - (evm) [#166](https://github.com/EscanBE/evermint/pull/166) Prevent refund gas fee if sender wasn't paid for it
 - (evm) [#169](https://github.com/EscanBE/evermint/pull/169) Support 256 blocks for `GetHashFn`
+- (app) [#177](https://github.com/EscanBE/evermint/pull/177) Fix staking hooks not available in some keepers
 
 ### API Breaking
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -214,16 +214,6 @@ func NewAppKeeper(
 		authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
 		authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
 	)
-	defer func() {
-		// register the staking hooks
-		// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
-		appKeepers.StakingKeeper.SetHooks(
-			stakingtypes.NewMultiStakingHooks(
-				appKeepers.DistrKeeper.Hooks(),
-				appKeepers.SlashingKeeper.Hooks(),
-			),
-		)
-	}()
 
 	appKeepers.DistrKeeper = distrkeeper.NewKeeper(
 		appCodec,
@@ -241,6 +231,15 @@ func NewAppKeeper(
 		runtime.NewKVStoreService(keys[slashingtypes.StoreKey]),
 		appKeepers.StakingKeeper,
 		authAddr,
+	)
+
+	// register the staking hooks
+	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
+	appKeepers.StakingKeeper.SetHooks(
+		stakingtypes.NewMultiStakingHooks(
+			appKeepers.DistrKeeper.Hooks(),
+			appKeepers.SlashingKeeper.Hooks(),
+		),
 	)
 
 	appKeepers.CrisisKeeper = crisiskeeper.NewKeeper(


### PR DESCRIPTION
Staking hooks was set by a defer function so it not available in some keepers which take `x/staking` keeper as struct, like `x/cpc`.