### PR TITLE
fix(rename-chain): Fix broken feature rename-chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (app) [#177](https://github.com/EscanBE/evermint/pull/177) Fix staking hooks not available in some keepers
 - (evm) [#184](https://github.com/EscanBE/evermint/pull/184) Warmup coinbase + custom-precompiled-contracts and fix some tests
 - (cpc) [#186](https://github.com/EscanBE/evermint/pull/186) Correct genesis import/export for `x/cpc`
+- (rename-chain) [#189](https://github.com/EscanBE/evermint/pull/189) Fix broken feature rename-chain
 
 ### API Breaking
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -15,7 +15,7 @@ const (
 
 	ApplicationHome = ".evermint"
 
-	GitHubRepo = "https://github.com/EscanBE/evermint" // must be well-formed url pattern: "https://github.com/owner/repo"
+	GitHubRepo = "https://github.com/EscanBE/" + ApplicationName // must be well-formed url pattern: "https://github.com/owner/repo"
 )
 
 // Denom

--- a/rename_chain/main.go
+++ b/rename_chain/main.go
@@ -187,6 +187,13 @@ func main() {
 
 	sed(path.Join("cmd", EvermintOg_ApplicationBinaryName, "root.go"), strings.ToUpper(EvermintOg_ApplicationName), strings.ToUpper(constants.ApplicationName))
 
+	{ // restore dependency in go.mod & go.sum
+		const invalidGethFork = "github.com/EscanBE/go-ethereum-for-" + constants.ApplicationName
+		const correctGethFork = "github.com/EscanBE/go-ethereum-for-evermint"
+		sed("go.mod", invalidGethFork, correctGethFork)
+		sed("go.sum", invalidGethFork, correctGethFork)
+	}
+
 	patternMarker := regexp.MustCompile(`marker\.(\w+)\("(\w+)"\)`)
 	for _, goFile := range goFiles {
 		if strings.HasSuffix(goFile, "_test.go") {

--- a/rename_chain/main.go
+++ b/rename_chain/main.go
@@ -1,5 +1,4 @@
 //go:build renamechain
-// +build renamechain
 
 package main
 
@@ -267,6 +266,11 @@ func main() {
 	}
 
 	launchAppWithDirectStd("mv", path.Join("cmd", EvermintOg_ApplicationBinaryName), path.Join("cmd", constants.ApplicationBinaryName))
+
+	{ // fix proto for Ethermint native module
+		launchAppWithDirectStd("mv", path.Join("proto", splOgGitHub[len(splOgGitHub)-1]), path.Join("proto", splNewGitHub[len(splNewGitHub)-1]))
+		launchAppWithDirectStd("make", "proto-gen")
+	}
 }
 
 func isLinux() bool {


### PR DESCRIPTION
Since the very first native module of Evermint introduced in https://github.com/EscanBE/evermint/pull/144, the feature `rename-chain` was broken because some proto issue.
This PR aims to fix it and another mis-replacement of external forks which contains word `evermint`.

Users who uses v0.47 only need to cherry-pick this commit [14fd8ab5d4c45fd8a7517b4f6b5a8da5ac241a62](https://github.com/EscanBE/evermint/commit/14fd8ab5d4c45fd8a7517b4f6b5a8da5ac241a62)