### PR TITLE
fix(cpc): add pseudocode when query `eth_getCode` and gRPC query code for custom precompiled contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#184](https://github.com/EscanBE/evermint/pull/184) Warmup coinbase + custom-precompiled-contracts and fix some tests
 - (cpc) [#186](https://github.com/EscanBE/evermint/pull/186) Correct genesis import/export for `x/cpc`
 - (rename-chain) [#189](https://github.com/EscanBE/evermint/pull/189) Fix broken feature rename-chain
+- (cpc) [#191](https://github.com/EscanBE/evermint/pull/191) Add pseudocode when query `eth_getCode` and gRPC query code for custom precompiled contracts
 
 ### API Breaking
 

--- a/x/cpc/types/constants.go
+++ b/x/cpc/types/constants.go
@@ -1,5 +1,23 @@
 package types
 
+import "encoding/hex"
+
 const (
 	GasVerifyEIP712 = 200_000
 )
+
+// PseudoCodePrecompiled is the pseudocode for the custom precompiled contracts.
+// Used to work around the issue that the UI fetches the contract code to check if the contract is a contract,
+// while precompiled contracts do not have code.
+var PseudoCodePrecompiled []byte
+
+func init() {
+	var err error
+	PseudoCodePrecompiled, err = hex.DecodeString(
+		// ABI string of "Custom Precompiled Contract"
+		"0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001b437573746f6d20507265636f6d70696c656420436f6e74726163740000000000",
+	)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 	"time"
 
+	cpctypes "github.com/EscanBE/evermint/v12/x/cpc/types"
+
 	evmvm "github.com/EscanBE/evermint/v12/x/evm/vm"
 
 	errorsmod "cosmossdk.io/errors"
@@ -197,6 +199,15 @@ func (k Keeper) Code(c context.Context, req *evmtypes.QueryCodeRequest) (*evmtyp
 	ctx := sdk.UnwrapSDKContext(c)
 
 	address := common.HexToAddress(req.Address)
+
+	{ // check if precompiled, returns a pseudocode to bypass logic check when importing token like Metamask
+		if k.cpcKeeper.HasCustomPrecompiledContract(ctx, address) {
+			return &evmtypes.QueryCodeResponse{
+				Code: cpctypes.PseudoCodePrecompiled,
+			}, nil
+		}
+	}
+
 	codeHash := k.GetCodeHash(ctx, address.Bytes())
 
 	var code []byte


### PR DESCRIPTION
Some UI like Metamask when add ERC-20 token, does get code of contract to check if the address is contract or not.

Custom precompiled contract is precompiled contract therefor does not have code so it mistakenly treated the input address (when import token to Metamask) as EoA and result action failed.

This PR returns a pseudo code for custom precompiled contracts, aim to workaround for the issue.